### PR TITLE
Add workaround for bpo-36880 crash to ctypes_patch

### DIFF
--- a/tests/test_ctypes_patch.py
+++ b/tests/test_ctypes_patch.py
@@ -1,0 +1,96 @@
+import ctypes
+import unittest
+
+from rubicon.objc import ctypes_patch
+
+class CtypesPatchTest(unittest.TestCase):
+    def test_patch_structure(self):
+        """A custom structure can be patched successfully."""
+
+        class TestStruct(ctypes.Structure):
+            _fields_ = [
+                ("spam", ctypes.c_int),
+                ("ham", ctypes.c_double),
+            ]
+        functype = ctypes.CFUNCTYPE(TestStruct)
+
+        # Before patching, the structure cannot be returned from a callback.
+        with self.assertRaises(TypeError):
+            @functype
+            def get_struct():
+                return TestStruct(123, 123)
+
+        ctypes_patch.make_callback_returnable(TestStruct)
+
+        # After patching, the structure can be returned from a callback.
+        @functype
+        def get_struct():
+            return TestStruct(123, 123)
+
+        # After being returned from the callback, the structure's data is intact.
+        struct = get_struct()
+        self.assertEqual(struct.spam, 123)
+        self.assertEqual(struct.ham, 123)
+
+    def test_patch_pointer(self):
+        """A custom pointer type can be patched successfully."""
+
+        class TestStruct(ctypes.Structure):
+            _fields_ = [
+                ("spam", ctypes.c_int),
+                ("ham", ctypes.c_double),
+            ]
+        pointertype = ctypes.POINTER(TestStruct)
+        functype = ctypes.CFUNCTYPE(pointertype)
+
+        original_struct = TestStruct(123, 123)
+
+        # Before patching, the pointer cannot be returned from a callback.
+        with self.assertRaises(TypeError):
+            @functype
+            def get_struct():
+                return pointertype(original_struct)
+
+        ctypes_patch.make_callback_returnable(pointertype)
+
+        # After patching, the structure can be returned from a callback.
+        @functype
+        def get_struct():
+            return pointertype(original_struct)
+
+        # After being returned from the callback, the pointer's data is intact.
+        struct_pointer = get_struct()
+        self.assertEqual(ctypes.addressof(struct_pointer.contents), ctypes.addressof(original_struct))
+        self.assertEqual(struct_pointer.contents.spam, 123)
+        self.assertEqual(struct_pointer.contents.ham, 123)
+
+    def test_no_patch_primitives(self):
+        """Primitive types cannot be patched."""
+
+        for tp in (ctypes.c_int, ctypes.c_double, ctypes.c_char_p, ctypes.c_void_p):
+            with self.subTest(tp):
+                with self.assertRaises(ValueError):
+                    ctypes_patch.make_callback_returnable(tp)
+
+    def test_patch_idempotent(self):
+        """Patching a type multiple times is equivalent to patching once."""
+
+        class TestStruct(ctypes.Structure):
+            _fields_ = [
+                ("spam", ctypes.c_int),
+                ("ham", ctypes.c_double),
+            ]
+        functype = ctypes.CFUNCTYPE(TestStruct)
+
+        for _ in range(5):
+            ctypes_patch.make_callback_returnable(TestStruct)
+    
+            # After patching, the structure can be returned from a callback.
+            @functype
+            def get_struct():
+                return TestStruct(123, 123)
+
+            # After being returned from the callback, the structure's data is intact.
+            struct = get_struct()
+            self.assertEqual(struct.spam, 123)
+            self.assertEqual(struct.ham, 123)

--- a/tests/test_ctypes_patch.py
+++ b/tests/test_ctypes_patch.py
@@ -3,6 +3,7 @@ import unittest
 
 from rubicon.objc import ctypes_patch
 
+
 class CtypesPatchTest(unittest.TestCase):
     def test_patch_structure(self):
         """A custom structure can be patched successfully."""
@@ -17,7 +18,7 @@ class CtypesPatchTest(unittest.TestCase):
         # Before patching, the structure cannot be returned from a callback.
         with self.assertRaises(TypeError):
             @functype
-            def get_struct():
+            def get_struct_fail():
                 return TestStruct(123, 123)
 
         ctypes_patch.make_callback_returnable(TestStruct)
@@ -48,7 +49,7 @@ class CtypesPatchTest(unittest.TestCase):
         # Before patching, the pointer cannot be returned from a callback.
         with self.assertRaises(TypeError):
             @functype
-            def get_struct():
+            def get_struct_fail():
                 return pointertype(original_struct)
 
         ctypes_patch.make_callback_returnable(pointertype)
@@ -84,7 +85,7 @@ class CtypesPatchTest(unittest.TestCase):
 
         for _ in range(5):
             ctypes_patch.make_callback_returnable(TestStruct)
-    
+
             # After patching, the structure can be returned from a callback.
             @functype
             def get_struct():

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ setenv =
     DYLD_LIBRARY_PATH = {toxinidir}/tests/objc
 
 [testenv:flake8]
-basepython = python3.6
+basepython = python3.7
 deps =
     flake8
 commands = flake8 {posargs}


### PR DESCRIPTION
This fixes the crash reported in beeware/toga#549 by adding a workaround for CPython/`ctypes` bug [bpo-36880](https://bugs.python.org/issue36880).

I've also made a PR to CPython with a fix for the bug itself (python/cpython#13364). This workaround is still important though, as it prevents the crash on Python versions that don't have the proper fix (which is currently all of them, and even once the patch gets merged it will only be included with Python 3.8 and newer, and maybe in a future Python 3.7 update).