### PR TITLE
Add Mojave to the build pool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
     - osx_image: xcode7.3
     # macOS 10.13 High Sierra
     - osx_image: xcode10.1
+    # macOS 10.13 Mojave
+    - osx_image: xcode10.2
     # macOS 10.12 Sierra
     - osx_image: xcode9.2
     - osx_image: xcode8.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,9 +50,11 @@ install:
   # pyenv's shims directory is not in the PATH by default.
   - export PATH="$(pyenv root)/shims:${PATH}"
   # These are the Python versions that we want to test on.
-  - pyenv install --skip-existing ${PY35}
-  - pyenv install --skip-existing ${PY36}
-  - pyenv install --skip-existing ${PY37}
+  # The CFLAGS prefix is to set up the include path so that zlib is available to the Python build
+  # This is needed on Mojave, but doesn't hurt other versions.
+  - CFLAGS="-I$(xcrun --show-sdk-path)/usr/include" pyenv install --skip-existing ${PY35}
+  - CFLAGS="-I$(xcrun --show-sdk-path)/usr/include" pyenv install --skip-existing ${PY36}
+  - CFLAGS="-I$(xcrun --show-sdk-path)/usr/include" pyenv install --skip-existing ${PY37}
   - pyenv global ${PY37} ${PY36} ${PY35} system
   - pip install --upgrade tox
   - make -f Makefile

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 OBJ_FILES=tests/objc/Thing.o tests/objc/Example.o tests/objc/BaseExample.o tests/objc/Blocks.o
 
-# By default, build a universal i386/x86_64 binary.
+# By default, build an x86_64 binary.
 # Modify here (or on the command line) to build for other architecture(s).
-EXTRA_FLAGS=-arch i386 -arch x86_64
+EXTRA_FLAGS=-arch x86_64
 
 all: tests/objc/librubiconharness.dylib
 

--- a/docs/background/releases.rst
+++ b/docs/background/releases.rst
@@ -6,6 +6,7 @@ Release History
 
 * Added a workaround for bpo-36880 (https://bugs.python.org/issue36880), which caused memory
 * Renamed the objc.async module to objc.eventloop to avoid keyword clashes.
+* Add support for Mojave
 * Add support for High Sierra
 * Removed support for Python 3.4
 * Removed support for Yosemite


### PR DESCRIPTION
Ensure that we're testing on the most recent OSX and XCode releases.

This involves deprecating x86 support from the tests, due to Mojave formally removing x86 from the supported architecture list.