### PR TITLE
Modernize and clean up the build configuration

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ include CHANGELOG.rst
 include CONTRIBUTING.md
 include Makefile
 include tox.ini
+recursive-include changes *.rst
 include docs/Makefile
 include docs/make.bat
 include docs/requirements_docs.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,15 +1,14 @@
-include LICENSE
-include README.rst
+# Note: See the PyPA documentation for a list of file names that are included/excluded by default:
+# https://packaging.python.org/guides/using-manifest-in/#how-files-are-included-in-an-sdist
+# Please only add entries here for files that are *not* already handled by default.
+
 include CHANGELOG.rst
 include CONTRIBUTING.md
-include tox.ini
 include Makefile
-recursive-include tests *.py
-recursive-include tests *.h
-recursive-include tests *.m
-recursive-include docs *.bat
-recursive-include docs *.png
-recursive-include docs *.py
-recursive-include docs *.rst
-recursive-include docs *.txt
-recursive-include docs Makefile
+include tox.ini
+include docs/Makefile
+include docs/make.bat
+include docs/requirements_docs.txt
+include docs/spelling_wordlist
+recursive-include docs *.png *.py *.rst
+recursive-include tests *.h *.m *.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,4 +12,5 @@ include docs/make.bat
 include docs/requirements_docs.txt
 include docs/spelling_wordlist
 recursive-include docs *.png *.py *.rst
+prune docs/_build
 recursive-include tests *.h *.m *.py

--- a/changes/template.rst
+++ b/changes/template.rst
@@ -4,6 +4,7 @@
 {% endif %}
 {% if sections[section] %}
 {% for category, val in definitions.items() if category in sections[section]%}
+
 {{ definitions[category]['name'] }}
 {{ underline * definitions[category]['name']|length }}
 
@@ -16,13 +17,10 @@
 {% endif %}
 {% if sections[section][category]|length == 0 %}
 No significant changes.
-
-{% else %}
 {% endif %}
-
 {% endfor %}
 {% else %}
-No significant changes.
 
+No significant changes.
 {% endif %}
 {% endfor %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools >= 42.0.0",
+    "setuptools >= 43.0.0",
     "wheel >= 0.32.0",
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,10 @@
+[build-system]
+requires = [
+    "setuptools >= 38.3.0",
+    "wheel >= 0.25.0",
+]
+build-backend = "setuptools.build_meta"
+
 [tool.towncrier]
 directory = "changes"
 package = "briefcase"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,5 +10,6 @@ directory = "changes"
 package = "rubicon.objc"
 filename = "docs/background/releases.rst"
 title_format = "{version} ({project_date})"
+issue_format = "`#{issue} <https://github.com/beeware/rubicon-objc/issues/{issue}>`_"
 template = "changes/template.rst"
 underlines = ["-", "^", "\""]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-    "setuptools >= 38.3.0",
-    "wheel >= 0.25.0",
+    "setuptools >= 42.0.0",
+    "wheel >= 0.32.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,4 @@ package = "rubicon.objc"
 filename = "docs/background/releases.rst"
 title_format = "{version} ({project_date})"
 template = "changes/template.rst"
+underlines = ["-", "^", "\""]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.towncrier]
 directory = "changes"
-package = "briefcase"
-package_dir = "src"
+package = "rubicon.objc"
 filename = "docs/background/releases.rst"
 title_format = "{version} ({project_date})"
 template = "changes/template.rst"

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,8 @@ classifiers =
     Programming Language :: Python :: 3 :: Only
     Topic :: Software Development
 license = New BSD
-license_file = LICENSE
+license_files =
+    LICENSE
 description = A bridge between an Objective C runtime environment and Python.
 long_description = file: README.rst
 long_description_content_type = text/x-rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifiers =
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3 :: Only
     Topic :: Software Development
 license = New BSD

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,8 +32,9 @@ namespace_packages =
     rubicon
 
 [options.packages.find]
-exclude =
-    tests
+include =
+    rubicon
+    rubicon.*
 
 [flake8]
 # https://flake8.readthedocs.org/en/latest/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,39 @@
 [metadata]
-description-file = README.rst
+name = rubicon-objc
+url = https://beeware.org/rubicon
+project_urls =
+    Funding = https://beeware.org/contributing/membership/
+    Documentation = https://rubicon-objc.readthedocs.io/en/latest/
+    Tracker = https://github.com/beeware/rubicon-objc/issues
+    Source = https://github.com/beeware/rubicon-objc
+author = Russell Keith-Magee
+author_email = russell@keith-magee.com
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: BSD License
+    Programming Language :: Objective C
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3 :: Only
+    Topic :: Software Development
+license = New BSD
+license_file = LICENSE
+description = A bridge between an Objective C runtime environment and Python.
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+
+[options]
+python_requires = >=3.5
+packages = find:
+namespace_packages =
+    rubicon
+
+[options.packages.find]
+exclude =
+    tests
 
 [flake8]
 # https://flake8.readthedocs.org/en/latest/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,6 @@
 [metadata]
 description-file = README.rst
 
-[bdist_wheel]
-universal=1
-
 [flake8]
 # https://flake8.readthedocs.org/en/latest/
 exclude=*.egg-info/*,.git/*,.tox/*,__pycache__,build/*,docs/*,env/*

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 import io
 import re
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
 with io.open('./rubicon/objc/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
@@ -12,39 +12,13 @@ with io.open('./rubicon/objc/__init__.py', encoding='utf8') as version_file:
         raise RuntimeError("Unable to find version string.")
 
 
-with io.open('README.rst', encoding='utf8') as readme:
-    long_description = readme.read()
-
-
 setup(
-    name='rubicon-objc',
     version=version,
-    description='A bridge between an Objective C runtime environment and Python.',
-    long_description=long_description,
-    author='Russell Keith-Magee',
-    author_email='russell@keith-magee.com',
-    url='https://beeware.org/rubicon',
-    packages=find_packages(exclude=['tests']),
-    python_requires='>=3.5',
-    namespace_packages=['rubicon'],
-    license='New BSD',
-    classifiers=[
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Programming Language :: Objective C',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3 :: Only',
-        'Topic :: Software Development',
-    ],
+    # The test_suite kwarg is only used by the setup.py test command,
+    # which is deprecated since setuptools 41.5.0:
+    # https://setuptools.readthedocs.io/en/latest/history.html#v41-5-0
+    # We still use setup.py test in our tox and CI configurations,
+    # but once we replace those calls with another test runner,
+    # this kwarg can be removed.
     test_suite='tests',
-    project_urls={
-        'Funding': 'https://beeware.org/contributing/membership/',
-        'Documentation': 'https://rubicon-objc.readthedocs.io/en/latest/',
-        'Tracker': 'https://github.com/beeware/rubicon-objc/issues',
-        'Source': 'https://github.com/beeware/rubicon-objc',
-    },
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import io
 import re
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,8 @@
-import io
 import re
 
 from setuptools import setup
 
-with io.open('./rubicon/objc/__init__.py', encoding='utf8') as version_file:
+with open('./rubicon/objc/__init__.py', encoding='utf8') as version_file:
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
     if version_match:
         version = version_match.group(1)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description=long_description,
     author='Russell Keith-Magee',
     author_email='russell@keith-magee.com',
-    url='http://beeware.org/rubicon',
+    url='https://beeware.org/rubicon',
     packages=find_packages(exclude=['tests']),
     python_requires='>=3.5',
     namespace_packages=['rubicon'],


### PR DESCRIPTION
This makes use of modern features like [PEP 517](https://www.python.org/dev/peps/pep-0517/), [PEP 518](https://www.python.org/dev/peps/pep-0518/), and [declarative metadata](https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files) in setup.cfg instead of setup.py.

Also includes some general cleanup of setup.py, setup.cfg, and MANIFEST.in.