### PR TITLE
Remove bit fields from "struct complex" test structure

### DIFF
--- a/tests/objc/Example.h
+++ b/tests/objc/Example.h
@@ -14,9 +14,6 @@ struct complex {
 	void (*callback)(void);
 	struct simple s;
 	struct complex *next;
-	unsigned int bitfield0:8;
-	unsigned int bitfield1:16;
-	unsigned int bitfield2:8;
 };
 
 /* objc_msgSend on i386, x86_64, ARM64; objc_msgSend_stret on ARM32. */

--- a/tests/objc/Example.m
+++ b/tests/objc/Example.m
@@ -233,9 +233,6 @@ static int _staticIntField = 11;
         .callback = NULL,
         .s = simple,
         .next = NULL,
-        .bitfield0 = 0,
-        .bitfield1 = 1,
-        .bitfield2 = 2,
     };
 }
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -619,7 +619,7 @@ class RubiconTest(unittest.TestCase):
 
         types.unregister_encoding_all(b'{simple=ii}')
         types.unregister_encoding_all(b'{simple}')
-        types.unregister_encoding_all(b'{complex=[4s]^?{simple=ii}^{complex}b8b16b8}')
+        types.unregister_encoding_all(b'{complex=[4s]^?{simple=ii}^{complex}}')
         types.unregister_encoding_all(b'{complex}')
 
         # Look up the method, so the return/argument types are decoded and the structs are registered.
@@ -630,7 +630,7 @@ class RubiconTest(unittest.TestCase):
 
         simple = struct_simple(123, 456)
         ret = Example.doStuffWithStruct_(simple)
-        struct_complex = types.ctype_for_encoding(b'{complex=[4s]^?{simple=ii}^{complex}b8b16b8}')
+        struct_complex = types.ctype_for_encoding(b'{complex=[4s]^?{simple=ii}^{complex}}')
         self.assertIsInstance(ret, struct_complex)
         self.assertEqual(struct_complex, types.ctype_for_encoding(b'{complex}'))
         self.assertEqual(list(ret.field_0), [1, 2, 3, 4])
@@ -638,15 +638,12 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(ret.field_2.field_0, 123)
         self.assertEqual(ret.field_2.field_1, 456)
         self.assertEqual(cast(ret.field_3, c_void_p).value, None)
-        self.assertEqual(ret.field_4, 0)
-        self.assertEqual(ret.field_5, 1)
-        self.assertEqual(ret.field_6, 2)
 
     def test_sequence_arg_to_struct(self):
         "Sequence arguments are converted to structures."
         Example = ObjCClass('Example')
 
-        ret = Example.extractSimpleStruct(([9, 8, 7, 6], None, (987, 654), None, 0, 0, 0))
+        ret = Example.extractSimpleStruct(([9, 8, 7, 6], None, (987, 654), None))
         struct_simple = types.ctype_for_encoding(b'{simple=ii}')
         self.assertIsInstance(ret, struct_simple)
         self.assertEqual(ret.field_0, 987)


### PR DESCRIPTION
ctypes (and the underlying libffi library) does not support passing structures containing bit fields by value. In the past this has silently worked without issues on x86 and x86_64, despite not being officially supported. However, Python 3.7.6 and Python 3.8.1 added an explicit check in ctypes to disallow this. This check has been removed again in Python 3.7.7 and Python 3.8.2 to avoid breaking working code in a bugfix release of Python, but Python 3.9 will probably contain the check again. In any case, it's safer to not rely on unsupported behavior like this in our tests.

Relevant CPython and libffi issues:

* https://bugs.python.org/issue39295
* https://bugs.python.org/issue16576
* https://bugs.python.org/issue16575
* libffi/libffi#33