### PR TITLE
Remove uses of DYLD_LIBRARY_PATH when running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         make
     - name: Test
       run: |
-        DYLD_LIBRARY_PATH=tests/objc python setup.py test
+        python setup.py test
 
   python-versions:
     name: Python compatibility test
@@ -78,7 +78,7 @@ jobs:
         make
     - name: Test
       run: |
-        DYLD_LIBRARY_PATH=tests/objc python setup.py test
+        python setup.py test
 
   package:
     name: Packaging checks

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,13 +33,4 @@ install:
   - python -m pip install .
 script:
   - make
-  # This next line *should* be:
-  #   DYLD_LIBRARY_PATH=tests/objc python setup.py test
-  # but the way Travis invokes Python through pyenv triggers macOS's System
-  # Integrity Protection (SIP) (see https://apple.stackexchange.com/a/216815).
-  # As a result, DYLD_LIBRARY_PATH isn't exposed to the Python process.
-  # Calling `$(pyenv which python)` instead of `python` uses a direct version
-  # of the python executable rather than the pyenv shims (which take a
-  # circuitous route performing multiple exec calls through various /usr/local
-  # locations). This avoids triggering SIP, so DYLD_LIBRARY_PATH is exposed.
-  - DYLD_LIBRARY_PATH=tests/objc "$(pyenv which python)" setup.py test
+  - python setup.py test

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,18 +10,8 @@ except Exception:
     OSX_VERSION = None
 
 try:
-    rubiconharness = load_library('rubiconharness')
+    rubiconharness = load_library(os.path.abspath('tests/objc/librubiconharness.dylib'))
 except ValueError:
-    try:
-        DYLD_LIBRARY_PATH = os.environ['DYLD_LIBRARY_PATH']
-        raise ValueError(
-            "Couldn't load Rubicon test harness library (DYLD_LIBRARY_PATH={DYLD_LIBRARY_PATH!r})".format(
-                DYLD_LIBRARY_PATH=DYLD_LIBRARY_PATH
-            )
-        )
-    except KeyError:
-        raise ValueError(
-            "Couldn't load Rubicon test harness library; DYLD_LIBRARY_PATH has not been set."
-        )
+    raise ValueError("Couldn't load Rubicon test harness library. Did you remember to run make?")
 
 faulthandler.enable()

--- a/tox.ini
+++ b/tox.ini
@@ -16,9 +16,6 @@ basepython =
 
 commands = {envpython} setup.py test
 
-setenv =
-    DYLD_LIBRARY_PATH = {toxinidir}/tests/objc
-
 [testenv:flake8]
 basepython = python3.8
 deps =


### PR DESCRIPTION
This is mainly because of [bpo-40198](https://bugs.python.org/issue40198) (I don't want to wait for the next Python bugfix releases or have to build Python by hand), but I think we're better off not using `DYLD_LIBRARY_PATH` no matter what. It seems that Apple doesn't really want anyone to use `DYLD_LIBRARY_PATH` outside of local development, and I wouldn't be surprised if they restrict its usage even further in the future.