### PR TITLE
Remove test_suite kwarg from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,4 @@ with open('./rubicon/objc/__init__.py', encoding='utf8') as version_file:
 
 setup(
     version=version,
-    # The test_suite kwarg is only used by the setup.py test command,
-    # which is deprecated since setuptools 41.5.0:
-    # https://setuptools.readthedocs.io/en/latest/history.html#v41-5-0
-    # We still use setup.py test in our tox and CI configurations,
-    # but once we replace those calls with another test runner,
-    # this kwarg can be removed.
-    test_suite='tests',
 )


### PR DESCRIPTION
We no longer use the deprecated setup.py test command.