### PR TITLE
Fix tox on Travis being run using Python 2 instead of 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ install:
   - python -m pip install --upgrade setuptools
   - python -m pip install tox
 script:
-  - tox -e py
+  - python -m tox -e py


### PR DESCRIPTION
I think this was introduced by #159, and because of #160 we didn't notice that anything broke on Travis.