### PR TITLE
Minor fixes to tox configuration (and documentation of same)

### DIFF
--- a/docs/how-to/contribute-code.rst
+++ b/docs/how-to/contribute-code.rst
@@ -9,6 +9,8 @@ to contribute code, please `fork the code`_ and `submit a pull request`_.
 .. _fork the code: https://github.com/pybee/rubicon-objc
 .. _submit a pull request: https://github.com/pybee/rubicon-objc/pulls
 
+.. _setup-dev-environment:
+
 Set up your development environment
 ===================================
 
@@ -45,6 +47,8 @@ Or, to run using a specific version of Python:
 
     (venv) $ tox -e py37
 
-substituting the version number that you want to target.
+substituting the version number that you want to target. You can also specify
+one of the pre-commit checks `flake8`, `docs` or `package` to check code
+formatting, documentation syntax and packaging metadata, respectively.
 
 Now you are ready to start hacking on Rubicon. Have fun!

--- a/docs/how-to/contribute-docs.rst
+++ b/docs/how-to/contribute-docs.rst
@@ -20,7 +20,8 @@ the other index files for clues.
 Build documentation locally
 ---------------------------
 
-To build the documentation locally, run::
+To build the documentation locally, :ref:`set up a development environment
+<setup-dev-environment>`, and run:
 
     $ tox -e docs
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,27 +17,23 @@ commands =
     pytest -vv
 
 [testenv:flake8]
-basepython = python3.8
 deps =
     flake8
 commands = flake8 {posargs}
 
 [testenv:docs]
-basepython = python3.8
 deps =
     -r{toxinidir}/docs/requirements_docs.txt
 commands =
     python setup.py build_sphinx -W
 
 [testenv:towncrier]
-basepython = python3.8
 deps =
     towncrier >= 18.5.0
 commands =
     towncrier {posargs}
 
 [testenv:package]
-basepython = python3.8
 deps =
     wheel
     twine
@@ -46,9 +42,11 @@ commands =
     python -m twine check dist/*
 
 [testenv:publish]
-basepython = python3.8
 deps =
     wheel
     twine
+passenv =
+    TWINE_USERNAME
+    TWINE_PASSWORD
 commands =
     python -m twine upload dist/*


### PR DESCRIPTION
This pr:

* Removes the explicit pinning of the Python version *inside* tox for pre-build commands. This pinning effectively *required* Python 3.8 to run the pre-test checks; removing the pin means "current version of Python" will be used. flake et al aren't *that* version specific, so we can force Python 3.8 in the CI environment, and give flexibility to end users.

* Ensures that the Twine environment variables are passed into the tox environment. Without this, publication will fail (discovered this the hard way after adding Tox to Briefcase, and attempting to publish a release!)

* Tweaks the documentation to make setup instructions more complete for documentation contributors, and provide explicit details on how to run pre-commit checks.