### PR TITLE
Fixes #146 - Ensure that timed callbacks clean up after themselves.

### DIFF
--- a/changes/146.bugfix.rst
+++ b/changes/146.bugfix.rst
@@ -1,0 +1,1 @@
+Corrected a slow memory leak caused every time an asyncio timed event handler triggered.

--- a/rubicon/objc/eventloop.py
+++ b/rubicon/objc/eventloop.py
@@ -142,6 +142,7 @@ class CFTimerHandle(events.TimerHandle):
         # Create a CF-compatible callback for a timer event
         def cf_timer_callback(cftimer, extra):
             callback(*args)
+            self._loop._timers.discard(self)
         return CFRunLoopTimerCallBack(cf_timer_callback)
 
     def __init__(self, *, loop, timeout, repeat, callback, args):

--- a/rubicon/objc/eventloop.py
+++ b/rubicon/objc/eventloop.py
@@ -142,7 +142,9 @@ class CFTimerHandle(events.TimerHandle):
         # Create a CF-compatible callback for a timer event
         def cf_timer_callback(cftimer, extra):
             callback(*args)
+            # Deregister the callback after it's been performed
             self._loop._timers.discard(self)
+
         return CFRunLoopTimerCallBack(cf_timer_callback)
 
     def __init__(self, *, loop, timeout, repeat, callback, args):

--- a/rubicon/objc/eventloop.py
+++ b/rubicon/objc/eventloop.py
@@ -142,12 +142,12 @@ class CFTimerHandle(events.TimerHandle):
         # Create a CF-compatible callback for a timer event
         def cf_timer_callback(cftimer, extra):
             callback(*args)
-            # Deregister the callback after it's been performed
+            # Deregister the callback after it has been performed.
             self._loop._timers.discard(self)
 
         return CFRunLoopTimerCallBack(cf_timer_callback)
 
-    def __init__(self, *, loop, timeout, repeat, callback, args):
+    def __init__(self, *, loop, timeout, callback, args):
         super().__init__(
             libcf.CFAbsoluteTimeGetCurrent() + timeout,
             self._cf_timer_callback(callback, args),
@@ -156,7 +156,6 @@ class CFTimerHandle(events.TimerHandle):
         )
 
         self._timeout = timeout
-        self._repeat = repeat
 
         # Retain a reference to the Handle
         self._loop._timers.add(self)
@@ -461,7 +460,6 @@ class CFEventLoop(unix_events.SelectorEventLoop):
         return CFTimerHandle(
             loop=self,
             timeout=0,
-            repeat=False,
             callback=context_callback(context, callback),
             args=args
         )
@@ -489,7 +487,6 @@ class CFEventLoop(unix_events.SelectorEventLoop):
         return CFTimerHandle(
             loop=self,
             timeout=delay,
-            repeat=False,
             callback=context_callback(context, callback),
             args=args
         )
@@ -504,7 +501,6 @@ class CFEventLoop(unix_events.SelectorEventLoop):
         return CFTimerHandle(
             loop=self,
             timeout=when - self.time(),
-            repeat=False,
             callback=context_callback(context, callback),
             args=args
         )


### PR DESCRIPTION
When a timed callback is installed on the asyncio event loop, ensure that when the callback fires, the callback is removed from the set of current events being fired.

Thanks to @dgelessus for identifying the cause, and @SamSchott for the original report and prototype fix.