### PR TITLE
Fixes #170 - Correct the usage of NSApplication.terminate()

### DIFF
--- a/changes/170.bugfix.rst
+++ b/changes/170.bugfix.rst
@@ -1,0 +1,1 @@
+Correct the invocation of NSApplication.terminate() when the lifecycle is ended.

--- a/rubicon/objc/eventloop.py
+++ b/rubicon/objc/eventloop.py
@@ -637,7 +637,7 @@ class CocoaLifecycle:
         self._application.run()
 
     def stop(self):
-        self._application.terminate()
+        self._application.terminate(None)
 
 
 class iOSLifecycle:


### PR DESCRIPTION
The CocoaLifecycle currently attempts to invoke NSApplication.terminate() - which is a problem, because that method doesn't exist. 

This change passes in a None argument as the "sender", which should (?) be legal in the context.