### PR TITLE
Tighten API of send_message

### DIFF
--- a/changes/174.feature.rst
+++ b/changes/174.feature.rst
@@ -1,1 +1,2 @@
-Added a ``varargs`` keyword argument to :func:`~rubicon.objc.runtime.send_message` to allow calling variadic methods more safely.
+Added a ``varargs`` keyword argument to :func:`~rubicon.objc.runtime.send_message` to allow calling variadic methods
+more safely.

--- a/changes/174.feature.rst
+++ b/changes/174.feature.rst
@@ -1,0 +1,1 @@
+Added a ``varargs`` keyword argument to :func:`~rubicon.objc.runtime.send_message` to allow calling variadic methods more safely.

--- a/changes/174.removal.rst
+++ b/changes/174.removal.rst
@@ -1,0 +1,4 @@
+Disallowed passing class names as :class:`str`/:class:`bytes` as the ``receiver`` argument of :func:`~rubicon.objc.runtime.send_message`.
+If you need to send a message to a class object (i. e. call a class method),
+use :class:`~rubicon.objc.api.ObjCClass` or :func:`~rubicon.objc.runtime.get_class` to look up the class,
+and pass the resulting :class:`~rubicon.objc.api.ObjCClass` or :class:`~rubicon.objc.runtime.Class` object as the receiver.

--- a/changes/174.removal.rst
+++ b/changes/174.removal.rst
@@ -1,4 +1,19 @@
-Disallowed passing class names as :class:`str`/:class:`bytes` as the ``receiver`` argument of :func:`~rubicon.objc.runtime.send_message`.
-If you need to send a message to a class object (i. e. call a class method),
-use :class:`~rubicon.objc.api.ObjCClass` or :func:`~rubicon.objc.runtime.get_class` to look up the class,
-and pass the resulting :class:`~rubicon.objc.api.ObjCClass` or :class:`~rubicon.objc.runtime.Class` object as the receiver.
+Tightened the API of :func:`~rubicon.objc.runtime.send_message`,
+removing some previously allowed shortcuts that were rarely used,
+or likely to be used by accident in an unsafe way.
+
+.. note::
+
+    In most cases,
+    Rubicon's high-level method call syntax provided by :class:`~rubicon.objc.api.ObjCInstance` can be used instead of :func:`~rubicon.objc.runtime.send_message`.
+    This syntax is almost always more convenient to use, more readable and less error-prone.
+    :func:`~rubicon.objc.runtime.send_message` should only be used in cases not supported by the high-level syntax.
+
+* Disallowed passing class names as :class:`str`/:class:`bytes` as the ``receiver`` argument of :func:`~rubicon.objc.runtime.send_message`.
+  If you need to send a message to a class object (i. e. call a class method),
+  use :class:`~rubicon.objc.api.ObjCClass` or :func:`~rubicon.objc.runtime.get_class` to look up the class,
+  and pass the resulting :class:`~rubicon.objc.api.ObjCClass` or :class:`~rubicon.objc.runtime.Class` object as the receiver.
+* Removed default values for :func:`~rubicon.objc.runtime.send_message`'s ``restype`` and ``argtypes`` keyword arguments.
+  Every :func:`~rubicon.objc.runtime.send_message` call now needs to have its return and argument types set explicitly.
+  This ensures that all arguments and the return value are converted correctly between (Objective-)C and Python.
+

--- a/changes/174.removal.rst
+++ b/changes/174.removal.rst
@@ -13,6 +13,13 @@ or likely to be used by accident in an unsafe way.
   If you need to send a message to a class object (i. e. call a class method),
   use :class:`~rubicon.objc.api.ObjCClass` or :func:`~rubicon.objc.runtime.get_class` to look up the class,
   and pass the resulting :class:`~rubicon.objc.api.ObjCClass` or :class:`~rubicon.objc.runtime.Class` object as the receiver.
+* Disallowed passing :class:`~ctypes.c_void_p` objects as the ``receiver`` argument of :func:`~rubicon.objc.runtime.send_message`.
+  The ``receiver`` argument now has to be of type :class:`~rubicon.objc.runtime.objc_id`,
+  or one of its subclasses (such as :class:`~rubicon.objc.runtime.Class`),
+  or one of its high-level equivalents (such as :class:`~rubicon.objc.api.ObjCInstance`).
+  This is the case for all Objective-C objects returned by Rubicon's high-level and low-level APIs.
+  If you need to send a message to an object pointer stored as :class:`~ctypes.c_void_p`,
+  :func:`~ctypes.cast` it to :class:`~rubicon.objc.runtime.objc_id` first.
 * Removed default values for :func:`~rubicon.objc.runtime.send_message`'s ``restype`` and ``argtypes`` keyword arguments.
   Every :func:`~rubicon.objc.runtime.send_message` call now needs to have its return and argument types set explicitly.
   This ensures that all arguments and the return value are converted correctly between (Objective-)C and Python.

--- a/changes/174.removal.rst
+++ b/changes/174.removal.rst
@@ -1,5 +1,5 @@
 Tightened the API of :func:`~rubicon.objc.runtime.send_message`,
-removing some previously allowed shortcuts that were rarely used,
+removing some previously allowed shortcuts and features that were rarely used,
 or likely to be used by accident in an unsafe way.
 
 .. note::
@@ -23,4 +23,17 @@ or likely to be used by accident in an unsafe way.
 * Removed default values for :func:`~rubicon.objc.runtime.send_message`'s ``restype`` and ``argtypes`` keyword arguments.
   Every :func:`~rubicon.objc.runtime.send_message` call now needs to have its return and argument types set explicitly.
   This ensures that all arguments and the return value are converted correctly between (Objective-)C and Python.
+* Disallowed passing more argument values than there are argument types in ``argtypes``.
+  This was previously allowed to support calling variadic methods -
+  any arguments beyond the types set in ``argtypes`` would be passed as varargs.
+  However,
+  this feature was easy to misuse by accident,
+  as it allowed passing extra arguments to *any* method,
+  even though most Objective-C methods are not variadic.
+  Extra arguments passed this way were silently ignored without causing an error or a crash.
+
+  To prevent accidentally passing too many arguments like this,
+  the number of arguments now has to exactly match the number of ``argtypes``.
+  Variadic methods can still be called,
+  but the varargs now need to be passed as a list into the separate ``varargs`` keyword arugment.
 

--- a/changes/174.removal.rst
+++ b/changes/174.removal.rst
@@ -1,39 +1,35 @@
-Tightened the API of :func:`~rubicon.objc.runtime.send_message`,
-removing some previously allowed shortcuts and features that were rarely used,
-or likely to be used by accident in an unsafe way.
+Tightened the API of :func:`~rubicon.objc.runtime.send_message`, removing some previously allowed shortcuts and
+features that were rarely used, or likely to be used by accident in an unsafe way.
 
 .. note::
 
-    In most cases,
-    Rubicon's high-level method call syntax provided by :class:`~rubicon.objc.api.ObjCInstance` can be used instead of :func:`~rubicon.objc.runtime.send_message`.
-    This syntax is almost always more convenient to use, more readable and less error-prone.
-    :func:`~rubicon.objc.runtime.send_message` should only be used in cases not supported by the high-level syntax.
+    In most cases, Rubicon's high-level method call syntax provided by :class:`~rubicon.objc.api.ObjCInstance` can be
+    used instead of :func:`~rubicon.objc.runtime.send_message`. This syntax is almost always more convenient to use,
+    more readable and less error-prone. :func:`~rubicon.objc.runtime.send_message` should only be used in cases
+    not supported by the high-level syntax.
 
-* Disallowed passing class names as :class:`str`/:class:`bytes` as the ``receiver`` argument of :func:`~rubicon.objc.runtime.send_message`.
-  If you need to send a message to a class object (i. e. call a class method),
-  use :class:`~rubicon.objc.api.ObjCClass` or :func:`~rubicon.objc.runtime.get_class` to look up the class,
-  and pass the resulting :class:`~rubicon.objc.api.ObjCClass` or :class:`~rubicon.objc.runtime.Class` object as the receiver.
-* Disallowed passing :class:`~ctypes.c_void_p` objects as the ``receiver`` argument of :func:`~rubicon.objc.runtime.send_message`.
-  The ``receiver`` argument now has to be of type :class:`~rubicon.objc.runtime.objc_id`,
-  or one of its subclasses (such as :class:`~rubicon.objc.runtime.Class`),
-  or one of its high-level equivalents (such as :class:`~rubicon.objc.api.ObjCInstance`).
-  This is the case for all Objective-C objects returned by Rubicon's high-level and low-level APIs.
-  If you need to send a message to an object pointer stored as :class:`~ctypes.c_void_p`,
-  :func:`~ctypes.cast` it to :class:`~rubicon.objc.runtime.objc_id` first.
-* Removed default values for :func:`~rubicon.objc.runtime.send_message`'s ``restype`` and ``argtypes`` keyword arguments.
-  Every :func:`~rubicon.objc.runtime.send_message` call now needs to have its return and argument types set explicitly.
-  This ensures that all arguments and the return value are converted correctly between (Objective-)C and Python.
-* Disallowed passing more argument values than there are argument types in ``argtypes``.
-  This was previously allowed to support calling variadic methods -
-  any arguments beyond the types set in ``argtypes`` would be passed as varargs.
-  However,
-  this feature was easy to misuse by accident,
-  as it allowed passing extra arguments to *any* method,
-  even though most Objective-C methods are not variadic.
-  Extra arguments passed this way were silently ignored without causing an error or a crash.
+* Disallowed passing class names as :class:`str`/:class:`bytes` as the ``receiver`` argument of
+  :func:`~rubicon.objc.runtime.send_message`. If you need to send a message to a class object (i. e. call a
+  class method), use :class:`~rubicon.objc.api.ObjCClass` or :func:`~rubicon.objc.runtime.get_class` to look up
+  the class, and pass the resulting :class:`~rubicon.objc.api.ObjCClass` or :class:`~rubicon.objc.runtime.Class` object
+  as the receiver.
+* Disallowed passing :class:`~ctypes.c_void_p` objects as the ``receiver`` argument of
+  :func:`~rubicon.objc.runtime.send_message`. The ``receiver`` argument now has to be of type
+  :class:`~rubicon.objc.runtime.objc_id`, or one of its subclasses (such as :class:`~rubicon.objc.runtime.Class`),
+  or one of its high-level equivalents (such as :class:`~rubicon.objc.api.ObjCInstance`). This is the case for all
+  Objective-C objects returned by Rubicon's high-level and low-level APIs. If you need to send a message to an object
+  pointer stored as :class:`~ctypes.c_void_p`, :func:`~ctypes.cast` it to :class:`~rubicon.objc.runtime.objc_id` first.
+* Removed default values for :func:`~rubicon.objc.runtime.send_message`'s ``restype`` and ``argtypes`` keyword
+  arguments. Every :func:`~rubicon.objc.runtime.send_message` call now needs to have its return and argument types
+  set explicitly. This ensures that all arguments and the return value are converted correctly between (Objective-)C
+  and Python.
+* Disallowed passing more argument values than there are argument types in ``argtypes``. This was previously allowed to
+  support calling variadic methods - any arguments beyond the types set in ``argtypes`` would be passed as varargs.
+  However, this feature was easy to misuse by accident, as it allowed passing extra arguments to *any* method,
+  even though most Objective-C methods are not variadic. Extra arguments passed this way were silently ignored without
+  causing an error or a crash.
 
-  To prevent accidentally passing too many arguments like this,
-  the number of arguments now has to exactly match the number of ``argtypes``.
-  Variadic methods can still be called,
-  but the varargs now need to be passed as a list into the separate ``varargs`` keyword arugment.
+  To prevent accidentally passing too many arguments like this, the number of arguments now has to exactly match
+  the number of ``argtypes``. Variadic methods can still be called, but the varargs now need to be passed as a list
+  into the separate ``varargs`` keyword arugment.
 

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -651,7 +651,7 @@ class ObjCInstance(object):
             # the ObjCInstance corresponding to the object from the cached objects
             # dictionary, effectively destroying the ObjCInstance.
             observer = send_message(
-                send_message('DeallocationObserver', 'alloc', restype=objc_id, argtypes=[]),
+                send_message(get_class('DeallocationObserver'), 'alloc', restype=objc_id, argtypes=[]),
                 'initWithObject:', self, restype=objc_id, argtypes=[objc_id]
             )
             libobjc.objc_setAssociatedObject(self, observer, observer, 0x301)

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -659,7 +659,7 @@ class ObjCInstance(object):
             # The observer is retained by the object we associate it to.  We release
             # the observer now so that it will be deallocated when the associated
             # object is deallocated.
-            send_message(observer, 'release')
+            send_message(observer, 'release', restype=None, argtypes=[])
 
         return self
 

--- a/rubicon/objc/collections.py
+++ b/rubicon/objc/collections.py
@@ -222,7 +222,7 @@ class ObjCListInstance(ObjCInstance):
             return self.objectAtIndex(index)
 
     def __len__(self):
-        return send_message(self.ptr, 'count', restype=NSUInteger)
+        return send_message(self.ptr, 'count', restype=NSUInteger, argtypes=[])
 
     def __iter__(self):
         for i in range(len(self)):
@@ -247,7 +247,7 @@ class ObjCListInstance(ObjCInstance):
         return len([x for x in self if x == value])
 
     def copy(self):
-        return ObjCInstance(send_message(self, 'copy', restype=objc_id))
+        return ObjCInstance(send_message(self, 'copy', restype=objc_id, argtypes=[]))
 
 
 @for_objcclass(NSMutableArray)
@@ -373,7 +373,7 @@ class ObjCDictInstance(ObjCInstance):
             yield key, self.objectForKey_(key)
 
     def copy(self):
-        return ObjCInstance(send_message(self, 'copy', restype=objc_id))
+        return ObjCInstance(send_message(self, 'copy', restype=objc_id, argtypes=[]))
 
 
 @for_objcclass(NSMutableDictionary)

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -624,7 +624,7 @@ def send_message(receiver, selector, *args, restype, argtypes):
 
     This is the equivalent of an Objective-C method call like ``[receiver sel:args]``.
 
-    :param receiver: The object on which to call the method, as an :class:`ObjCInstance`, :class:`objc_id`, or :class:`~ctypes.c_void_p`.
+    :param receiver: The object on which to call the method, as an :class:`ObjCInstance` or :class:`objc_id`.
     :param selector: The name of the method as a :class:`str`, :class:`bytes`, or :class:`SEL`.
     :param args: The method arguments.
     :param restype: The return type of the method.
@@ -636,12 +636,11 @@ def send_message(receiver, selector, *args, restype, argtypes):
     except AttributeError:
         pass
 
-    if isinstance(receiver, objc_id):
-        pass
-    elif type(receiver) == c_void_p:
-        receiver = cast(receiver, objc_id)
-    else:
-        raise TypeError("Invalid type for receiver: {tp.__module__}.{tp.__qualname__}".format(tp=type(receiver)))
+    if not isinstance(receiver, objc_id):
+        raise TypeError(
+            "Receiver must be an ObjCInstance or objc_id, not {tp.__module__}.{tp.__qualname__}"
+            .format(tp=type(receiver))
+        )
 
     selector = SEL(selector)
 

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -619,7 +619,7 @@ def should_use_fpret(restype):
         return False
 
 
-def send_message(receiver, selector, *args, restype=c_void_p, argtypes=None):
+def send_message(receiver, selector, *args, restype, argtypes):
     """Call a method on the receiver with the given selector and arguments.
 
     This is the equivalent of an Objective-C method call like ``[receiver sel:args]``.
@@ -627,9 +627,8 @@ def send_message(receiver, selector, *args, restype=c_void_p, argtypes=None):
     :param receiver: The object on which to call the method, as an :class:`ObjCInstance`, :class:`objc_id`, or :class:`~ctypes.c_void_p`.
     :param selector: The name of the method as a :class:`str`, :class:`bytes`, or :class:`SEL`.
     :param args: The method arguments.
-    :param restype: The return type of the method. Defaults to :class:`~ctypes.c_void_p`.
-    :param argtypes: The argument types of the method, as a :class:`list`. Defaults to an empty list
-        (i. e. all arguments are treated as C varargs).
+    :param restype: The return type of the method.
+    :param argtypes: The argument types of the method, as a :class:`list`.
     """
 
     try:
@@ -645,8 +644,6 @@ def send_message(receiver, selector, *args, restype=c_void_p, argtypes=None):
         raise TypeError("Invalid type for receiver: {tp.__module__}.{tp.__qualname__}".format(tp=type(receiver)))
 
     selector = SEL(selector)
-    if argtypes is None:
-        argtypes = []
 
     # Choose the correct version of objc_msgSend based on return type.
     # Use libobjc['name'] instead of libobjc.name to get a new function object

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -624,9 +624,7 @@ def send_message(receiver, selector, *args, restype=c_void_p, argtypes=None):
 
     This is the equivalent of an Objective-C method call like ``[receiver sel:args]``.
 
-    :param receiver: The object on which to call the method. This may be an Objective-C object
-        (as an :class:`ObjCInstance`, :class:`objc_id`, or :class:`~ctypes.c_void_p`),
-        or an Objective-C class name (as a :class:`str` or :class:`bytes`).
+    :param receiver: The object on which to call the method, as an :class:`ObjCInstance`, :class:`objc_id`, or :class:`~ctypes.c_void_p`.
     :param selector: The name of the method as a :class:`str`, :class:`bytes`, or :class:`SEL`.
     :param args: The method arguments.
     :param restype: The return type of the method. Defaults to :class:`~ctypes.c_void_p`.
@@ -641,8 +639,6 @@ def send_message(receiver, selector, *args, restype=c_void_p, argtypes=None):
 
     if isinstance(receiver, objc_id):
         pass
-    elif isinstance(receiver, (str, bytes)):
-        receiver = cast(get_class(receiver), objc_id)
     elif type(receiver) == c_void_p:
         receiver = cast(receiver, objc_id)
     else:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -352,14 +352,14 @@ class RubiconTest(unittest.TestCase):
 
         obj = Example.alloc().init()
 
-        self.assertEqual(send_message(obj, "accessBaseIntField", restype=c_int), 22)
-        self.assertEqual(send_message(obj, "accessIntField", restype=c_int), 33)
+        self.assertEqual(send_message(obj, "accessBaseIntField", restype=c_int, argtypes=[]), 22)
+        self.assertEqual(send_message(obj, "accessIntField", restype=c_int, argtypes=[]), 33)
 
         send_message(obj, "mutateBaseIntFieldWithValue:", 8888, restype=None, argtypes=[c_int])
         send_message(obj, "mutateIntFieldWithValue:", 9999, restype=None, argtypes=[c_int])
 
-        self.assertEqual(send_message(obj, "accessBaseIntField", restype=c_int), 8888)
-        self.assertEqual(send_message(obj, "accessIntField", restype=c_int), 9999)
+        self.assertEqual(send_message(obj, "accessBaseIntField", restype=c_int, argtypes=[]), 8888)
+        self.assertEqual(send_message(obj, "accessIntField", restype=c_int, argtypes=[]), 9999)
 
     def test_static_field(self):
         "A static field on a class can be accessed and mutated"
@@ -683,9 +683,18 @@ class RubiconTest(unittest.TestCase):
         Example = ObjCClass('Example')
         example = Example.alloc().init()
 
-        self.assertEqual(send_message(example, "intSizedStruct", restype=struct_int_sized).x, b"abc")
-        self.assertEqual(send_message(example, "oddlySizedStruct", restype=struct_oddly_sized).x, b"abcd")
-        self.assertEqual(send_message(example, "largeStruct", restype=struct_large).x, b"abcdefghijklmnop")
+        self.assertEqual(
+            send_message(example, "intSizedStruct", restype=struct_int_sized, argtypes=[]).x,
+            b"abc",
+        )
+        self.assertEqual(
+            send_message(example, "oddlySizedStruct", restype=struct_oddly_sized, argtypes=[]).x,
+            b"abcd",
+        )
+        self.assertEqual(
+            send_message(example, "largeStruct", restype=struct_large, argtypes=[]).x,
+            b"abcdefghijklmnop",
+        )
 
     def test_object_return(self):
         "If a method or field returns an object, you get an instance of that type returned"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -346,6 +346,35 @@ class RubiconTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             obj.mutateIntFieldWithValue_(123, "extra argument")
 
+    def test_method_incorrect_argument_count_send(self):
+        """Attempting to call a method with send_message with an incorrect number of arguments throws an exception."""
+
+        Example = ObjCClass('Example')
+        obj = Example.alloc().init()
+
+        with self.assertRaises(TypeError):
+            send_message(obj, 'accessIntField', 'extra argument 1', restype=c_int, argtypes=[])
+
+        with self.assertRaises(TypeError):
+            send_message(obj, 'mutateIntFieldWithValue:', restype=None, argtypes=[c_int])
+
+        with self.assertRaises(TypeError):
+            send_message(obj, 'mutateIntFieldWithValue:', 123, 'extra_argument', restype=None, argtypes=[c_int])
+
+    def test_method_varargs_send(self):
+        """A variadic method can be called using send_message."""
+
+        NSString = ObjCClass('NSString')
+        formatted = send_message(
+            NSString,
+            'stringWithFormat:',
+            at('This is a %@ with %@'),
+            varargs=[at('string'), at('placeholders')],
+            restype=objc_id,
+            argtypes=[objc_id],
+        )
+        self.assertEqual(str(ObjCInstance(formatted)), 'This is a string with placeholders')
+
     def test_method_send(self):
         "An instance method can be invoked with send_message."
         Example = ObjCClass('Example')


### PR DESCRIPTION
This change is a little opinionated - it removes a couple of special features from `send_message` that, in my opinion, are either too error-prone or too rarely used to be worth the extra complexity. See the individual commits for explanations on why I think it would be best to remove each of these features.

I'm open to feedback on these changes. If you think any of these features are legitimately useful and removing them would be a bad idea, please let me know.

Also, this is obviously a breaking change - it removes features that were previously documented and supported. As we're still before version 1.0, this is technically fine. I don't think any of these features are widely used enough to require a proper deprecation process, but I'm open to feedback here as well.