### PR TITLE
Change ObjCMethod to use send_message instead of calling IMPs directly

### DIFF
--- a/changes/177.bugfix.rst
+++ b/changes/177.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed :func:`~rubicon.objc.runtime.send_message` not accepting :class:`~rubicon.objc.runtime.SEL` objects for the
+``selector`` parameter. The documentation stated that this is allowed, but actually doing so caused a type error.

--- a/changes/177.feature.rst
+++ b/changes/177.feature.rst
@@ -1,4 +1,4 @@
-Changed :class:`~rubicon.objc.api.ObjCMethod` to call methods using :func:`~rubicon.objc.runtime.send_message`
+Changed ``ObjCMethod``` to call methods using :func:`~rubicon.objc.runtime.send_message`
 instead of calling :class:`~rubicon.objc.runtime.IMP`\s directly. This is mainly an internal change and should not
 affect most existing code, although it may improve compatibility with Objective-C code that makes heavy use of runtime
 reflection and method manipulation (such as swizzling).

--- a/changes/177.feature.rst
+++ b/changes/177.feature.rst
@@ -1,0 +1,4 @@
+Changed :class:`~rubicon.objc.api.ObjCMethod` to call methods using :func:`~rubicon.objc.runtime.send_message`
+instead of calling :class:`~rubicon.objc.runtime.IMP`\s directly. This is mainly an internal change and should not
+affect most existing code, although it may improve compatibility with Objective-C code that makes heavy use of runtime
+reflection and method manipulation (such as swizzling).

--- a/changes/177.removal.rst
+++ b/changes/177.removal.rst
@@ -1,0 +1,1 @@
+Removed the ``ObjCMethod`` class from the public API, as there was no good way to use it from external code.

--- a/docs/reference/rubicon-objc-api.rst
+++ b/docs/reference/rubicon-objc-api.rst
@@ -63,9 +63,14 @@ Objective-C classes
 
         The method's return type, as a :mod:`ctypes` type, or ``None`` for ``void`` methods.
 
-    .. attribute:: argtypes
+    .. attribute:: imp_argtypes
 
         The method's argument types, as a sequence of :mod:`ctypes` types. The types of the implicit ``self`` and ``_cmd`` parameters, :class:`~rubicon.objc.runtime.objc_id` and :class:`~rubicon.objc.runtime.SEL`, are included here.
+
+    .. attribute:: method_argtypes
+
+        The method's argument types, as a sequence of :mod:`ctypes` types. This is identical to :attr:`imp_argtypes`,
+        except that the types of the implicit ``self`` and ``_cmd`` parameters are not included.
 
 Standard Objective-C and Foundation classes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/reference/rubicon-objc-api.rst
+++ b/docs/reference/rubicon-objc-api.rst
@@ -47,31 +47,6 @@ Objective-C classes
 
 .. autoclass:: ObjCMetaClass(name_or_ptr)
 
-.. autoclass:: ObjCMethod
-
-    .. automethod:: __call__
-
-    .. attribute:: selector
-
-        The method's selector, as a :class:`~rubicon.objc.runtime.SEL`.
-
-    .. attribute:: encoding
-
-        The method's signature type encoding, as :class:`bytes`.
-
-    .. attribute:: restype
-
-        The method's return type, as a :mod:`ctypes` type, or ``None`` for ``void`` methods.
-
-    .. attribute:: imp_argtypes
-
-        The method's argument types, as a sequence of :mod:`ctypes` types. The types of the implicit ``self`` and ``_cmd`` parameters, :class:`~rubicon.objc.runtime.objc_id` and :class:`~rubicon.objc.runtime.SEL`, are included here.
-
-    .. attribute:: method_argtypes
-
-        The method's argument types, as a sequence of :mod:`ctypes` types. This is identical to :attr:`imp_argtypes`,
-        except that the types of the implicit ``self`` and ``_cmd`` parameters are not included.
-
 Standard Objective-C and Foundation classes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/reference/rubicon-objc-api.rst
+++ b/docs/reference/rubicon-objc-api.rst
@@ -67,14 +67,6 @@ Objective-C classes
 
         The method's argument types, as a sequence of :mod:`ctypes` types. The types of the implicit ``self`` and ``_cmd`` parameters, :class:`~rubicon.objc.runtime.objc_id` and :class:`~rubicon.objc.runtime.SEL`, are included here.
 
-    .. attribute:: imp
-
-        The method's implementation function pointer, as an :class:`~rubicon.objc.runtime.IMP`.
-
-        .. note::
-
-            This function pointer cannot be called directly, as it does not carry any type information. To call the method, call the :class:`ObjCMethod` object itself (see :meth:`__call__`), and not its :attr:`imp`. This way Rubicon determines the correct argument and return types automatically, checks the types of the passed arguments, and converts the arguments and return value as needed.
-
 Standard Objective-C and Foundation classes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -32,7 +32,6 @@ __all__ = [
     'ObjCClass',
     'ObjCInstance',
     'ObjCMetaClass',
-    'ObjCMethod',
     'ObjCProtocol',
     'Protocol',
     'at',

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -3,7 +3,7 @@ import decimal
 import enum
 import inspect
 from ctypes import (
-    CFUNCTYPE, POINTER, ArgumentError, Array, Structure, Union, addressof, byref, c_bool, c_char_p, c_int, c_uint,
+    CFUNCTYPE, POINTER, Array, Structure, Union, addressof, byref, c_bool, c_char_p, c_int, c_uint,
     c_uint8, c_ulong, c_void_p, cast, sizeof, string_at
 )
 
@@ -152,27 +152,18 @@ class ObjCMethod(object):
         else:
             converted_args = args
 
-        try:
-            result = send_message(
-                receiver, self.selector, *converted_args,
-                restype=self.restype, argtypes=self.method_argtypes,
-            )
-        except ArgumentError as error:
-            # Add more useful info to argument error exceptions, then reraise.
-            error.args = (
-                error.args[0]
-                + ' (selector = {self.name}, argtypes = {self.method_argtypes}, encoding = {self.encoding})'
-                .format(self=self),
-            )
-            raise
-        else:
-            if not convert_result:
-                return result
+        result = send_message(
+            receiver, self.selector, *converted_args,
+            restype=self.restype, argtypes=self.method_argtypes,
+        )
 
-            # Convert result to python type if it is a instance or class pointer.
-            if self.restype is not None and issubclass(self.restype, objc_id):
-                result = py_from_ns(result, _auto=True)
+        if not convert_result:
             return result
+
+        # Convert result to python type if it is a instance or class pointer.
+        if self.restype is not None and issubclass(self.restype, objc_id):
+            result = py_from_ns(result, _auto=True)
+        return result
 
 
 class ObjCPartialMethod(object):

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -86,7 +86,6 @@ class ObjCMethod(object):
 
         self.selector = libobjc.method_getName(method)
         self.name = self.selector.name
-        self.pyname = self.name.replace(b':', b'_')
         self.encoding = libobjc.method_getTypeEncoding(method)
         self.restype, *self.argtypes = ctypes_for_method_encoding(self.encoding)
 

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -1,7 +1,7 @@
 import os
 from ctypes import (
-    CDLL, CFUNCTYPE, POINTER, Structure, Union, addressof, alignment, byref, c_bool, c_char_p, c_double, c_float,
-    c_int, c_longdouble, c_size_t, c_uint, c_uint8, c_void_p, cast, memmove, sizeof, util,
+    ArgumentError, CDLL, CFUNCTYPE, POINTER, Structure, Union, addressof, alignment, byref, c_bool, c_char_p,
+    c_double, c_float, c_int, c_longdouble, c_size_t, c_uint, c_uint8, c_void_p, cast, memmove, sizeof, util,
 )
 
 from . import ctypes_patch
@@ -698,7 +698,18 @@ def send_message(receiver, selector, *args, restype, argtypes, varargs=None):
     send = libobjc[send_name]
     send.restype = restype
     send.argtypes = [objc_id, SEL] + argtypes
-    result = send(receiver, selector, *args, *varargs)
+
+    try:
+        result = send(receiver, selector, *args, *varargs)
+    except ArgumentError as error:
+        # Add more useful info to argument error exceptions, then reraise.
+        error.args = (
+            error.args[0]
+            + ' (selector = {selector}, argtypes = {argtypes})'
+            .format(selector=selector, argtypes=argtypes),
+        )
+        raise
+
     if restype == c_void_p:
         result = c_void_p(result)
     return result

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -671,7 +671,8 @@ def send_message(receiver, selector, *args, restype, argtypes, varargs=None):
             .format(tp=type(receiver))
         )
 
-    selector = SEL(selector)
+    if not isinstance(selector, SEL):
+        selector = SEL(selector)
 
     if len(args) != len(argtypes):
         raise TypeError(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -390,6 +390,14 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(send_message(obj, "accessBaseIntField", restype=c_int, argtypes=[]), 8888)
         self.assertEqual(send_message(obj, "accessIntField", restype=c_int, argtypes=[]), 9999)
 
+    def test_send_sel(self):
+        """send_message accepts a SEL object as the selector parameter."""
+        Example = ObjCClass('Example')
+
+        obj = Example.alloc().init()
+
+        self.assertEqual(send_message(obj, SEL("accessIntField"), restype=c_int, argtypes=[]), 33)
+
     def test_static_field(self):
         "A static field on a class can be accessed and mutated"
         Example = ObjCClass('Example')


### PR DESCRIPTION
This makes all method calls go through `send_message`/`objc_msgSend`, rather than having some of them bypass that mechanism and call method `IMP`s directly. Aside from eliminating a redundant code path, this should improve compatibility with swizzling and other runtime method manipulation. It also seems to give slightly better performance (which makes sense - all compiler-generated Objective-C method calls go through `objc_msgSend`, so Apple will have optimized that function a lot).