### PR TITLE
Add an entry point for running the event loop cooperatively.

### DIFF
--- a/changes/182.bugfix.rst
+++ b/changes/182.bugfix.rst
@@ -1,0 +1,2 @@
+A cooperative entry point for starting event loop has been added. This corrects
+a problem seen when using Python 3.8 on iOS.

--- a/rubicon/objc/__init__.py
+++ b/rubicon/objc/__init__.py
@@ -6,7 +6,7 @@
 # __version__ = '1.2.3'       # Final Release
 # __version__ = '1.2.3.post1' # Post Release 1
 
-__version__ = '0.4.0'
+__version__ = '0.4.1.dev1'
 
 # Import commonly used submodules right away.
 # The first few imports are only included for clarity. They are not strictly necessary, because the from-imports below

--- a/rubicon/objc/eventloop.py
+++ b/rubicon/objc/eventloop.py
@@ -457,7 +457,7 @@ class CFEventLoop(unix_events.SelectorEventLoop):
             self.stop()
 
     def run_forever_cooperatively(self, lifecycle=None):
-        """A non-blocking version of run_forever.
+        """A non-blocking version of :meth:`run_forever`.
 
         This may seem like nonsense; however, an iOS app is not expected to
         invoke a blocking "main event loop" method. As a result, we need to
@@ -465,7 +465,7 @@ class CFEventLoop(unix_events.SelectorEventLoop):
         to the main app to start the actual event loop.
 
         The implementation is effectively all the parts of a call to
-        ``run_forever()``, but without any of the shutdown/cleanup logic.
+        :meth:`run_forever()`, but without any of the shutdown/cleanup logic.
         """
         self._set_lifecycle(lifecycle if lifecycle else CFLifecycle(self._cfrunloop))
 


### PR DESCRIPTION
Under Cocoa, `run_forever()` is fully integrated with the main CFRunLoop. This makes `run_forever()` a blocking call.

However, on iOS, there is no blocking call to "run" the app (at least, not one that the user has access to). As a result, we need to kick off the Python event loop, but not actually block; the "blocking" is done internally to iOS.

Historically, we have used `run_forever()` to do this. Despite the name, the method returned immediately; and although the loop shutdown logic was invoked, it didn't affect the operation of the event loop inside the iOS app.

However, in Python 3.8, this shutdown logic puts the event loop into a state where it shuts down correctly, leaving `asyncio` in a state where it thinks there's no active event loop.

This PR adds a new entry point (`run_forever_cooperatively()`) that does the *startup* portions of `run_forever()`, but skips the shutdown handling. This allows iOS apps to trigger event loop integration without causing an immediate shutdown.

AFAICT, there's no need for a `shutdown` method to do the cleanup. If the iOS event loop ever exits, the app is exiting; and the only things asyncio does on shutdown is housekeeping to make sure that the existence of the event loop has been purged. This is only needed in the case where you may want to start another event loop, which can't ever happen in the iOS context.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
