### PR TITLE
Improve performance of method calls and ObjCInstance creation

### DIFF
--- a/changes/183.bugfix.rst
+++ b/changes/183.bugfix.rst
@@ -1,0 +1,2 @@
+Improved performance of Objective-C method calls and
+:class:`~rubicon.objc.api.ObjCInstance` creation in many cases.

--- a/changes/183.removal.rst
+++ b/changes/183.removal.rst
@@ -1,0 +1,9 @@
+Removed automatic conversion of Objective-C numbers (``NSNumber`` and
+``NSDecmialNumber``) to Python numbers when received from Objective-C
+(i. e. returned from an Objective-C method or property or passed into an
+Objective-C method implemented in Python). This automatic conversion
+significantly slowed down every Objective-C method call that returns an object,
+even though the conversion doesn't apply to most method calls. If you have code
+that receives an Objective-C number and needs to use it as a Python number,
+please convert it explicitly using :func:`~rubicon.objc.api.py_from_ns` or an
+appropriate Objective-C method.

--- a/changes/183.removal.rst
+++ b/changes/183.removal.rst
@@ -7,3 +7,14 @@ even though the conversion doesn't apply to most method calls. If you have code
 that receives an Objective-C number and needs to use it as a Python number,
 please convert it explicitly using :func:`~rubicon.objc.api.py_from_ns` or an
 appropriate Objective-C method.
+
+As a side effect, ``NSNumber`` and ``NSDecimalNumber`` values stored in
+Objective-C collections (``NSArray``, ``NSDictionary``) are also no longer
+automatically unwrapped when retrieved from the collection, even when using
+Python syntax to access the collection. For example, if ``arr`` is a
+``NSArray`` of integer ``NSNumber``s, ``arr[0]`` now returns an Objective-C
+``NSNumber`` and not a Python ``int`` as before. If you need the contents of an
+Objective-C collection as Python values, you can use
+:func:`~rubicon.objc.api.py_from_ns` to convert either single values
+(e. g. ``py_from_ns(arr[0])``) or the entire collection
+(e. g. ``py_from_ns(arr)``).

--- a/changes/183.removal.rst
+++ b/changes/183.removal.rst
@@ -1,5 +1,5 @@
 Removed automatic conversion of Objective-C numbers (``NSNumber`` and
-``NSDecmialNumber``) to Python numbers when received from Objective-C
+``NSDecimalNumber``) to Python numbers when received from Objective-C
 (i. e. returned from an Objective-C method or property or passed into an
 Objective-C method implemented in Python). This automatic conversion
 significantly slowed down every Objective-C method call that returns an object,

--- a/docs/reference/rubicon-objc-api.rst
+++ b/docs/reference/rubicon-objc-api.rst
@@ -262,17 +262,6 @@ Converting objects between Objective-C and Python
 
     Alias for :func:`ns_from_py`.
 
-.. _auto-objc-python-conversion:
-
-Automatic conversion of Objective-C objects to Python
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-When Python code receives an Objective-C object, Rubicon will automatically convert certain kinds of objects to their Python counterparts, using a subset of the conversions performed by :func:`py_from_ns`:
-
-* :class:`~rubicon.objc.runtime.objc_id` objects are converted to :class:`ObjCInstance` before further conversion
-* :class:`NSDecimalNumber` objects are converted to :class:`decimal.Decimal`
-* :class:`NSNumber` objects are converted to :class:`bool`, :class:`int`, or :class:`float` based on their contents
-
 .. _custom-classes-and-protocols:
 
 Creating custom Objective-C classes and protocols
@@ -338,7 +327,7 @@ Parameter and return types
 
 The argument and return types of a Python-created Objective-C method are determined based on the Python method's type annotations. The annotations may contain any :mod:`ctypes` type, as well as any of the Python types accepted by :func:`~rubicon.objc.types.ctype_for_type`. If a parameter or the return type is not specified, it defaults to :class:`ObjCInstance`. The ``self`` parameter is special-cased --- its type is always :class:`ObjCInstance`, even if annotated otherwise. To annotate a method as returning ``void``, set its return type to ``None``.
 
-Before being passed to the Python method, the arguments are :ref:`converted automatically <auto-objc-python-conversion>`. If the method returns an Objective-C object, it is converted using :func:`ns_from_py` before being returned to Objective-C. These automatic conversions can be disabled by using :func:`objc_rawmethod` instead of :func:`objc_method`.
+Before being passed to the Python method, any object parameters (:class:`~rubicon.objc.runtime.objc_id`) are automatically converted to :class:`ObjCInstance`. If the method returns an Objective-C object, it is converted using :func:`ns_from_py` before being returned to Objective-C. These automatic conversions can be disabled by using :func:`objc_rawmethod` instead of :func:`objc_method`.
 
 The implicit ``_cmd`` parameter is not passed to the Python method, as it is normally redundant and not needed. If needed, the ``_cmd`` parameter can be accessed by using :func:`objc_rawmethod` instead of :func:`objc_method`.
 

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -173,7 +173,7 @@ class ObjCPartialMethod(object):
         super().__init__()
 
         self.name_start = name_start
-        self.methods = {}
+        self.methods = {}  # Initialized in ObjCClass._load_methods
 
     def __repr__(self):
         return "{cls.__module__}.{cls.__qualname__}({self.name_start!r})".format(cls=type(self), self=self)
@@ -191,14 +191,14 @@ class ObjCPartialMethod(object):
             rest = frozenset(kwargs) | frozenset(("",))
 
         try:
-            meth, order = self.methods[rest]
+            name, order = self.methods[rest]
         except KeyError:
             raise ValueError(
                 "No method was found starting with {!r} and with keywords {}\nKnown keywords are:\n{}"
                 .format(self.name_start, set(kwargs), "\n".join(repr(keywords) for keywords in self.methods))
             )
 
-        meth = ObjCMethod(meth)
+        meth = receiver.objc_class._cache_method(name)
         args += [kwargs[name] for name in order]
         return meth(receiver, *args)
 
@@ -1195,7 +1195,7 @@ class ObjCClass(ObjCInstance, type):
 
             # order is rest without the dummy "" part
             order = rest[:-1]
-            partial.methods[frozenset(rest)] = (method, order)
+            partial.methods[frozenset(rest)] = (name, order)
 
 
 class ObjCMetaClass(ObjCClass):

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -749,17 +749,12 @@ class ObjCInstance(object):
         else:
             method = None
 
-        if method is not None:
-            # If the partial method can only resolve to one method that takes no arguments,
-            # return that method directly, instead of a mostly useless partial method.
-            if set(method.methods) == {frozenset()}:
-                method, _ = method.methods[frozenset()]
-                method = ObjCMethod(method)
+        if method is None or set(method.methods) == {frozenset()}:
+            # Find a method whose full name matches the given name if no partial method was found,
+            # or the partial method can only resolve to a single method that takes no arguments.
+            # The latter case avoids returning partial methods in cases where a regular method works just as well.
+            method = self.objc_class._cache_method(name.replace("_", ":"))
 
-            return ObjCBoundMethod(method, self)
-
-        # See if there's a method whose full name matches the given name.
-        method = self.objc_class._cache_method(name.replace("_", ":"))
         if method:
             return ObjCBoundMethod(method, self)
         else:

--- a/tests/test_NSArray.py
+++ b/tests/test_NSArray.py
@@ -1,7 +1,7 @@
 import unittest
 
 from rubicon.objc import (
-    NSArray, NSMutableArray, NSObject, ObjCClass, objc_method, objc_property,
+    NSArray, NSMutableArray, NSObject, ObjCClass, objc_method, objc_property, py_from_ns,
 )
 from rubicon.objc.collections import ObjCListInstance
 
@@ -276,13 +276,13 @@ class PythonObjectTest(unittest.TestCase):
 
         # If it's set through a method call, it becomes an objc instance
         obj2 = PrimitiveListAttrContainer.alloc().initWithList_([4, 5, 6])
-        self.assertEqual(obj2.data, [4, 5, 6])
         self.assertIsInstance(obj2.data, ObjCListInstance)
+        self.assertEqual(py_from_ns(obj2.data), [4, 5, 6])
 
         # If it's set by direct attribute access, it becomes a Python object.
         obj2.data = [7, 8, 9]
-        self.assertEqual(obj2.data, [7, 8, 9])
         self.assertIsInstance(obj2.data, list)
+        self.assertEqual(obj2.data, [7, 8, 9])
 
     def test_primitive_list_property(self):
         class PrimitiveListContainer(NSObject):
@@ -299,16 +299,16 @@ class PythonObjectTest(unittest.TestCase):
                 return self
 
         obj1 = PrimitiveListContainer.alloc().init()
-        self.assertEqual(obj1.data, [1, 2, 3])
         self.assertIsInstance(obj1.data, ObjCListInstance)
+        self.assertEqual(py_from_ns(obj1.data), [1, 2, 3])
 
         obj2 = PrimitiveListContainer.alloc().initWithList_([4, 5, 6])
-        self.assertEqual(obj2.data, [4, 5, 6])
         self.assertIsInstance(obj2.data, ObjCListInstance)
+        self.assertEqual(py_from_ns(obj2.data), [4, 5, 6])
 
         obj2.data = [7, 8, 9]
-        self.assertEqual(obj2.data, [7, 8, 9])
         self.assertIsInstance(obj2.data, ObjCListInstance)
+        self.assertEqual(py_from_ns(obj2.data), [7, 8, 9])
 
     def test_object_list_attribute(self):
         class ObjectListAttrContainer(NSObject):
@@ -373,5 +373,5 @@ class PythonObjectTest(unittest.TestCase):
         obj = MultitypeListContainer.alloc().init()
 
         obj.data = [4, True, 'Hello', example]
-        self.assertEqual(obj.data, [4, True, 'Hello', example])
         self.assertIsInstance(obj.data, ObjCListInstance)
+        self.assertEqual(py_from_ns(obj.data), [4, True, 'Hello', example])


### PR DESCRIPTION
Several performance optimizations for method calls and `ObjCInstance` creation, to reduce the performance problems described in #183.

All of these optimizations are purely internal and shouldn't affect code that uses Rubicon, with one exception: `NSNumber` and `NSDecimalNumber` objects are no longer automatically converted to Python number values when received from Objective-C. This is unfortunately a breaking change, so it may break some existing code, which would need to be fixed by adding `py_from_ns` calls in the appropriate places. But of all the changes I made, this one resulted in the biggest performance improvement - it made every object-returning method call twice as fast - so I think the breakage is worth it. It also makes the API more consistent: objects received from Objective-C are now never automatically converted to Python values anymore, only to `ObjCInstance` or its subclasses.

I made these optimizations based on profiling a short piece of test code that makes the same calls repeatedly in a loop:

```python
import cProfile

from rubicon import objc

def to_profile():
    for _ in range(1000):
        objc.NSObject.new().autorelease()

cProfile.run("to_profile()", "output.pstat")
```

Before these optimizations, the test code took about 560 ms to run on my machine. With these optimizations, it only takes about 180 ms. This is a noticeable improvement, but still not that great compared to PyObjC, which takes about 18 ms for the same number of method calls (tested with `for _ in range(1000): NSObject.new().description()` instead, because PyObjC does reference management automatically).

Optimizing this further would require some deeper changes to Rubicon, specifically the `DeallocationObserver` class. Every Objective-C object that is wrapped in an `ObjCInstance` has a `DeallocationObserver` instance attached (to handle some things related to Python/Objective-C reference management), and the code needed for this has a noticeable impact on the performance of creating `ObjCInstance`s for new objects. (I'll make a separate issue about this.)

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct