### PR TITLE
Make ObjCInstance cache weak and avoid using DeallocationObserver

### DIFF
--- a/changes/185.misc.rst
+++ b/changes/185.misc.rst
@@ -1,0 +1,14 @@
+Changed the way :class:`~rubicon.objc.api.ObjCInstance`\s are cached.
+The custom ``DeallocationObserver`` class is no longer used to manage the cache
+for most objects - instead the cache has been made a weak value dictionary,
+meaning that entries are automatically removed if they are no longer referenced
+from Python.
+
+:class:`~rubicon.objc.api.ObjCInstance`\s with custom Python attributes are
+still managed using strong references and ``DeallocationObserver``, because
+these attributes are only stored on the Python side and not on the Objective-C
+object, so they could otherwise be lost if an object has only Objective-C
+references and no Python references. The ``DeallocationObserver`` for an
+:class:`~rubicon.objc.api.ObjCInstance` is now only created once it has a
+custom Python attribute added to it, which improves the performance of wrapping
+most other objects that don't use custom Python attributes.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1154,7 +1154,7 @@ class RubiconTest(unittest.TestCase):
 
     def test_objcinstance_python_attribute(self):
         """Python attributes can be added to an ObjCInstance."""
-        
+
         Thing = ObjCClass("Thing")
         thing = Thing.alloc().init()
 


### PR DESCRIPTION
This implements the change I described in #185.

This improves the performance of wrapping Objective-C objects in most cases, because most ObjCInstances never have custom Python attributes added and now no longer need to have a ``DeallocationObserver`` associated. Profiling some test code that creates objects in a loop, the execution time of the test code went down from about 180 - 200 ms to about 120 - 140 ms.

```python
import cProfile

from rubicon import objc

def to_profile():
    for _ in range(1000):
        objc.NSObject.new().autorelease()

cProfile.run("to_profile()", "output.pstat")
```

Linking #183 because this is a performance improvement.

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct