### PR TITLE
Refactor/simplify some parts of Python-defined ObjC class creation

### DIFF
--- a/changes/189.misc.rst
+++ b/changes/189.misc.rst
@@ -1,0 +1,1 @@
+Refactored some parts of the internal logic for defining Objective-C classes from Python.

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -273,7 +273,7 @@ class objc_method(object):
 
     def register(self, cls, attr):
         name = attr.replace("_", ":")
-        cls.imp_keep_alive_table[name] = add_method(cls, name, self, self.encoding)
+        add_method(cls, name, self, self.encoding)
 
     def protocol_register(self, proto, attr):
         name = attr.replace('_', ':')
@@ -309,7 +309,7 @@ class objc_classmethod(object):
 
     def register(self, cls, attr):
         name = attr.replace("_", ":")
-        cls.imp_keep_alive_table[name] = add_method(cls.objc_class, name, self, self.encoding)
+        add_method(cls.objc_class, name, self, self.encoding)
 
     def protocol_register(self, proto, attr):
         name = attr.replace('_', ':')
@@ -409,11 +409,11 @@ class objc_property(object):
 
         setter_name = 'set' + attr[0].upper() + attr[1:] + ':'
 
-        cls.imp_keep_alive_table[attr] = add_method(
+        add_method(
             cls.ptr, attr, _objc_getter,
             [self.vartype, ObjCInstance, SEL],
         )
-        cls.imp_keep_alive_table[setter_name] = add_method(
+        add_method(
             cls.ptr, setter_name, _objc_setter,
             [None, ObjCInstance, SEL, self.vartype],
         )
@@ -454,7 +454,7 @@ class objc_rawmethod(object):
 
     def register(self, cls, attr):
         name = attr.replace("_", ":")
-        cls.imp_keep_alive_table[name] = add_method(cls, name, self, self.encoding)
+        add_method(cls, name, self, self.encoding)
 
     def protocol_register(self, proto, attr):
         raise TypeError('Protocols cannot have method implementations, use objc_method instead of objc_rawmethod')
@@ -984,11 +984,6 @@ class ObjCClass(ObjCInstance, type):
             'forced_properties': set(),
             # Mapping of first keyword -> ObjCPartialMethod instances
             'partial_methods': {},
-            # Mapping of name -> CFUNCTYPE callback function
-            # This only contains the IMPs of methods created in Python,
-            # which need to be kept from being garbage-collected.
-            # It does not contain any other methods, do not use it for calling methods.
-            'imp_keep_alive_table': {},
         }
 
         # On Python 3.6 and later, the class namespace may contain a __classcell__ attribute that must be passed on

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -1488,7 +1488,7 @@ class ObjCProtocol(ObjCInstance):
             return False
 
     def __subclasscheck__(self, subclass):
-        """Check whether the given class or protool conforms to this protocol.
+        """Check whether the given class or protocol conforms to this protocol.
 
         If the given object is not an Objective-C class or protocol, :class:`TypeError` is raised.
 


### PR DESCRIPTION
This is just an internal refactoring and shouldn't have any visible effect to users.

Instances of `objc_method`, `objc_property`, etc. have callback methods that are called by `ObjCClass` and `ObjCProtocol` when a new Objective-C class/protocol is created from Python. These callback methods contain the code that adds the method/property/etc. in question to the Objective-C class/property.

For class creation there were two callback methods, `pre_register` and `register`, which were called at different stages of the class creation process. This PR changes it so that only one callback method (`class_register`) is needed, which does the job of both `pre_register` and `register` at a single point during class creation. This makes the logic a bit easier to follow, and as a side effect some checks in `ObjCClass.__new__` are also no longer needed.

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct