### PR TITLE
Unpin sphinx_tabs dependency in requirements_docs.txt

### DIFF
--- a/changes/194.misc.rst
+++ b/changes/194.misc.rst
@@ -1,0 +1,1 @@
+Updated ``sphinx_tabs`` to fix a deprecation warning when building the docs.

--- a/docs/requirements_docs.txt
+++ b/docs/requirements_docs.txt
@@ -3,4 +3,4 @@ sphinxcontrib-spelling
 pyenchant
 sphinx-autobuild
 sphinx_rtd_theme
-sphinx_tabs==1.1.8
+sphinx_tabs

--- a/docs/requirements_docs.txt
+++ b/docs/requirements_docs.txt
@@ -1,6 +1,6 @@
-sphinx
-sphinxcontrib-spelling
 pyenchant
+sphinx
 sphinx-autobuild
 sphinx-rtd-theme
 sphinx-tabs
+sphinxcontrib-spelling

--- a/docs/requirements_docs.txt
+++ b/docs/requirements_docs.txt
@@ -2,5 +2,5 @@ sphinx
 sphinxcontrib-spelling
 pyenchant
 sphinx-autobuild
-sphinx_rtd_theme
-sphinx_tabs
+sphinx-rtd-theme
+sphinx-tabs


### PR DESCRIPTION
This fixes the deprecation warning when building the docs.

Not sure why this was pinned in the first place when none of the other dependencies in the same file are. Possibly just a copy-paste artifact.

(I also did some other minor cleanups in requirements_docs.txt while I'm here)

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
