### PR TITLE
Add macOS 11 (Big Sur) to GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Set up Python 3.5
       uses: actions/setup-python@v1
       with:
-        python-version: 3.5
+        python-version: 3.7
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,26 @@ jobs:
   smoke:
     name: Smoke test (3.5)
     needs: beefore
-    runs-on: macOS-latest
+    runs-on: macos-10.15
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.5
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.5
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade setuptools
+        python -m pip install tox
+    - name: Test
+      run: |
+        tox -e py
+
+  macos-versions:
+    name: macOS compatibility test
+    needs: smoke
+    runs-on: macos-11.0
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.5
@@ -54,7 +73,7 @@ jobs:
   python-versions:
     name: Python compatibility test
     needs: smoke
-    runs-on: macOS-latest
+    runs-on: macos-10.15
     strategy:
       max-parallel: 4
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: macos-11.0
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.5
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
         python-version: 3.7

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@
 # https://packaging.python.org/guides/using-manifest-in/#how-files-are-included-in-an-sdist
 # Please only add entries here for files that are *not* already handled by default.
 
+include .readthedocs.yml
 include CHANGELOG.rst
 include CONTRIBUTING.md
 include tox.ini

--- a/changes/195.feature.rst
+++ b/changes/195.feature.rst
@@ -1,0 +1,1 @@
+Added official support for macOS 11 (Big Sur).

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -84,7 +84,7 @@ class AsyncCallTests(unittest.TestCase):
 
         # The co-routine will be queued after 0.2 seconds.
         self.assertGreaterEqual(end - start, 0.2)
-        self.assertLess(end - start, 0.35)
+        self.assertLess(end - start, 0.4)
 
     def test_call_at(self):
         start = time.time()
@@ -95,7 +95,7 @@ class AsyncCallTests(unittest.TestCase):
 
         # The co-routine will be queued after 0.2 seconds.
         self.assertGreaterEqual(end - start, 0.2)
-        self.assertLess(end - start, 0.35)
+        self.assertLess(end - start, 0.4)
 
 
 class AsyncReaderWriterTests(unittest.TestCase):


### PR DESCRIPTION
According to [the docs](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on), GitHub Actions already supports macOS Big Sur. Let's see how well rubicon-objc works there. (This will be the first time I test rubicon-objc on macOS 11 - I don't have it installed on any of my machines yet.)

For the moment I'm keeping our main Python compatibility test matrix on macOS 10.15 (as it is currently) and test only with Python 3.5 on macOS 11 (like our Travis-based CI does it for the older macOS versions).

## PR Checklist:
- [ ] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
