### PR TITLE
Replace manual version extraction with setup.cfg attr directive

### DIFF
--- a/changes/196.misc.rst
+++ b/changes/196.misc.rst
@@ -1,0 +1,5 @@
+Replaced regex-based version extraction code in setup.py with
+``version = attr: ...`` in setup.cfg, now that setuptools (since
+`version 46.4.0 <https://setuptools.readthedocs.io/en/latest/history.html#v46-4-0>`__)
+supports extracting ``attr: ...`` values statically where possible without
+having to import the module in question at runtime.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools >= 43.0.0",
+    "setuptools >= 46.4.0",
     "wheel >= 0.32.0",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
 name = rubicon-objc
+version = attr: rubicon.objc.__version__
 url = https://beeware.org/rubicon
 project_urls =
     Funding = https://beeware.org/contributing/membership/

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,3 @@
-import re
-
 from setuptools import setup
 
-with open('./rubicon/objc/__init__.py', encoding='utf8') as version_file:
-    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M)
-    if version_match:
-        version = version_match.group(1)
-    else:
-        raise RuntimeError("Unable to find version string.")
-
-
-setup(
-    version=version,
-)
+setup()


### PR DESCRIPTION
This now works, because setuptools 46.4.0 and later extract attribute values statically where possible, rather than having to import the module in question at runtime. The latter fails in the case of rubicon-objc when building on a system that doesn't have a working Objective-C runtime.

Followup to https://github.com/beeware/rubicon-objc/pull/156#discussion_r405227677.

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
