### PR TITLE
Reduce Travis CI matrix to minimum (closes #197)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,7 @@ branches:
   only:
     - master
 os: osx
-matrix:
-  include:
-    # OSX 10.11 El Capitan
-    - osx_image: xcode7.3
-    # macOS 10.12 Sierra
-    - osx_image: xcode8.3
-    - osx_image: xcode9.2
-    # macOS 10.13 High Sierra
-    - osx_image: xcode10.1
-    # macOS 10.14 Mojave
-    - osx_image: xcode10.2
+osx_image: xcode7.3 # OSX 10.11 El Capitan
 language: generic
 cache:
   directories:

--- a/changes/197.removal.rst
+++ b/changes/197.removal.rst
@@ -1,0 +1,11 @@
+Removed macOS 10.12 through 10.14 from our automatic test matrix,
+due to pricing changes in one of our CI services (Travis CI).
+OS X 10.11 is still included in the test matrix for now,
+but will probably be removed relatively soon.
+Automatic tests on macOS 10.15 and 11.0 are unaffected
+as they run on a different CI service (GitHub Actions).
+
+Rubicon will continue to support macOS 10.14 and earlier on a best-effort
+basis, even though compatibility is no longer tested automatically.
+If you encounter any bugs or other problems with Rubicon on these older macOS
+versions, please report them!


### PR DESCRIPTION
Instead of removing our Travis setup entirely, this reduces the matrix to a single build on the oldest available Xcode/macOS version (Xcode 7.3 on Mac OS X 10.11). This way we still have *some* CI testing on old macOS versions until the remainig free Travis CI credits run out (and at that point we can completely remove Travis CI).

As far as I know, Travis CI counts credits per owner (i. e. user or organization), so this will use up Travis CI credits that could theoretically also be used by other BeeWare projects. But as I understand it, almost all other BeeWare projects have moved off of Travis by now, so this shouldn't be a big issue.

Closes #197.

## PR Checklist:
- [ ] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
