### PR TITLE
Autorelease objects which we own

### DIFF
--- a/changes/200.feature.rst
+++ b/changes/200.feature.rst
@@ -1,0 +1,1 @@
+Autorelease Objective-C instances when the corresponding Python instance is destroyed.

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -15,6 +15,7 @@ stand alone.
 
    get-started
    type-mapping
+   memory-management
    protocols
    async
    c-functions

--- a/docs/how-to/memory-management.rst
+++ b/docs/how-to/memory-management.rst
@@ -7,12 +7,11 @@ will automatically track where variables are referenced and free memory when
 the reference count drops to zero whereas Objective-C uses explicit reference
 counting to manage memory. The methods ``retain``, ``release`` and
 ``autorelease`` are used to increase and decrease the reference counts as
-described in the `Apple developer documentation`_. When enabling automatic
-reference counting (ARC), the appropriate calls for memory management will be
-inserted for you at compile-time. However, since Rubicon Objective-C operates
-at runtime, it cannot make use of ARC.
-
-.. _Apple developer documentation: https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/MemoryMgmt/Articles/MemoryMgmt.html
+described in the `Apple developer documentation
+<https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/MemoryMgmt/Articles/MemoryMgmt.html>`__.
+When enabling automatic reference counting (ARC), the appropriate calls for
+memory management will be inserted for you at compile-time. However, since
+Rubicon Objective-C operates at runtime, it cannot make use of ARC.
 
 You won’t have to manage reference counts in Python, Rubicon Objective-C will
 do that work for you. It does so by tracking when you gain ownership of an

--- a/docs/how-to/memory-management.rst
+++ b/docs/how-to/memory-management.rst
@@ -1,5 +1,5 @@
 ===========================================
-Memory-management for Objective-C instances
+Memory management for Objective-C instances
 ===========================================
 
 Reference counting works differently in Objective-C compared to Python. Python
@@ -13,12 +13,12 @@ When enabling automatic reference counting (ARC), the appropriate calls for
 memory management will be inserted for you at compile-time. However, since
 Rubicon Objective-C operates at runtime, it cannot make use of ARC.
 
-You won’t have to manage reference counts in Python, Rubicon Objective-C will
+You won't have to manage reference counts in Python, Rubicon Objective-C will
 do that work for you. It does so by tracking when you gain ownership of an
 object. This is the case when you create an Objective-C instance using a method
-whose name begins with “alloc”, “new”, “copy”, or “mutableCopy” or explicitly
-call ``retain``. Rubicon Objet-C will then insert a ``release`` call when the
-Python variable that corresponds to the Objective-C instance is deallocated.
+whose name begins with "alloc", "new", "copy", or "mutableCopy". Rubicon
+Objective-C will then insert a ``release`` call when the Python variable that
+corresponds to the Objective-C instance is deallocated.
 
 You will only need to pay attention to reference counting in case of **weak
 references**. In Objective-C, creating a **weak reference** means that the

--- a/docs/how-to/memory-management.rst
+++ b/docs/how-to/memory-management.rst
@@ -21,7 +21,7 @@ whose name begins with “alloc”, “new”, “copy”, or “mutableCopy” 
 call ``retain``. Rubicon Objet-C will then insert a ``release`` call when the
 Python variable that corresponds to the Objective-C instance is deallocated.
 
-You will only need to pay attention to reference counting is in case of **weak
+You will only need to pay attention to reference counting in case of **weak
 references**. In Objective-C, creating a **weak reference** means that the
 reference count of the object is not incremented and the object will still be
 deallocated when no strong references remain. Any weak references to the object

--- a/docs/how-to/memory-management.rst
+++ b/docs/how-to/memory-management.rst
@@ -20,7 +20,11 @@ whose name begins with "alloc", "new", "copy", or "mutableCopy". Rubicon
 Objective-C will then insert a ``release`` call when the Python variable that
 corresponds to the Objective-C instance is deallocated.
 
-You will only need to pay attention to reference counting in case of **weak
+An exception to this is when you manually ``retain`` an object. Rubicon
+Objective-C will not keep track of such retain calls and you will be
+responsible to insert appropriate ``release`` calls yourself.
+
+You will also need to pay attention to reference counting in case of **weak
 references**. In Objective-C, creating a **weak reference** means that the
 reference count of the object is not incremented and the object will still be
 deallocated when no strong references remain. Any weak references to the object

--- a/docs/how-to/memory-management.rst
+++ b/docs/how-to/memory-management.rst
@@ -1,0 +1,50 @@
+===========================================
+Memory-management for Objective-C instances
+===========================================
+
+Reference counting works differently in Objective-C compared to Python. Python
+will automatically track where variables are referenced and free memory when
+the reference count drops to zero whereas Objective-C uses explicit reference
+counting to manage memory. The methods ``retain``, ``release`` and
+``autorelease`` are used to increase and decrease the reference counts as
+described in the `Apple developer documentation`_. When enabling automatic
+reference counting (ARC), the appropriate calls for memory management will be
+inserted for you at compile-time. However, since Rubicon Objective-C operates
+at runtime, it cannot make use of ARC.
+
+.. _Apple developer documentation: https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/MemoryMgmt/Articles/MemoryMgmt.html
+
+You won’t have to manage reference counts in Python, Rubicon Objective-C will
+do that work for you. It does so by tracking when you gain ownership of an
+object. This is the case when you create an Objective-C instance using a method
+whose name begins with “alloc”, “new”, “copy”, or “mutableCopy” or explicitly
+call ``retain``. Rubicon Objet-C will then insert a ``release`` call when the
+Python variable that corresponds to the Objective-C instance is deallocated.
+
+You will only need to pay attention to reference counting is in case of **weak
+references**. In Objective-C, creating a **weak reference** means that the
+reference count of the object is not incremented and the object will still be
+deallocated when no strong references remain. Any weak references to the object
+are then set to ``nil``.
+
+Some objects will store references to other objects as a weak reference. Such
+properties will be declared in the Apple developer documentation as
+"@property(weak)" or "@property(assign)". This is commonly the case for
+delegates. For example, in the code below, the ``NSOutlineView`` only stores a
+weak reference to the object which is assigned to its delegate property:
+
+.. code-block:: python
+
+    from rubicon.objc import NSObject, ObjCClass
+    from rubicon.objc.runtime import load_library
+
+    app_kit = load_library("AppKit")
+    NSOutlineView = ObjCClass("NSOutlineView")
+
+    outline_view = NSOutlineView.alloc().init()
+    delegate = NSObject.alloc().init()
+
+    outline_view.delegate = delegate
+
+You will need to keep a reference to the Python variable ``delegate`` so that
+the corresponding Objective-C instance does not get deallocated.

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -657,8 +657,8 @@ class ObjCInstance(object):
         return self
 
     def __del__(self):
-        # Release all objects which we own, except for autorelease pools.
-        if self._needs_release and self.objc_class.name != 'NSAutoreleasePool':
+
+        if self._needs_release:
             send_message(self, "release", restype=objc_id, argtypes=[])
 
     def __str__(self):

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -657,11 +657,9 @@ class ObjCInstance(object):
         return self
 
     def __del__(self):
-        # Autorelease all objects which we own, except for autorelease pools.
-        # We use autorelease instead of release here to prevent instances without a Python
-        # reference but with an Obj-C reference from being released too early.
+        # Release all objects which we own, except for autorelease pools.
         if self._needs_release and self.objc_class.name != 'NSAutoreleasePool':
-            send_message(self, "autorelease", restype=objc_id, argtypes=[])
+            send_message(self, "release", restype=objc_id, argtypes=[])
 
     def __str__(self):
         """Get a human-readable representation of ``self``.

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -656,6 +656,17 @@ class ObjCInstance(object):
 
         return self
 
+    def retain(self):
+        """
+        Manually increment the reference count of the corresponding objc object
+
+        The objc object is sent a dealloc message when its reference count reaches 0.
+        Use this method to retain objects which we don't own.
+        """
+        self._needs_release = True
+        result = send_message(self, "retain", restype=objc_id, argtypes=[])
+        return ObjCInstance(result)
+
     def release(self):
         """
         Manually decrement the reference count of the corresponding objc object

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -164,7 +164,7 @@ class ObjCMethod(object):
         # Convert result to python type if it is a instance or class pointer.
         if self.restype is not None and issubclass(self.restype, objc_id):
             result = ObjCInstance(result)
-            
+
         # Mark for release if we acquire ownership of an object. Do not autorelease here because
         # we might retain a Python reference while the Obj-C reference goes out of scope.
         if any(self.name.startswith(prefix) for prefix in (b'alloc', b'new', b'copy', b'mutableCopy')):

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -656,6 +656,17 @@ class ObjCInstance(object):
 
         return self
 
+    def release(self):
+        """
+        Manually decrement the reference count of the corresponding objc object
+
+        The objc object is sent a dealloc message when its reference count reaches 0. Calling
+        this method manually should not be necessary, the object will be automatically
+        released when the Python object is deallocated.
+        """
+        self._needs_release = False
+        send_message(self, "release", restype=objc_id, argtypes=[])
+
     def __del__(self):
         """
         Release the corresponding objc instance if we own it, i.e., if it was returned by

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -661,8 +661,9 @@ class ObjCInstance(object):
         Manually decrement the reference count of the corresponding objc object
 
         The objc object is sent a dealloc message when its reference count reaches 0. Calling
-        this method manually should not be necessary, the object will be automatically
-        released when the Python object is deallocated.
+        this method manually should not be necessary, unless the object was explicitly
+        ``retain``\\ed before. Objects returned from ``.alloc().init...(...)`` and similar calls
+        are released automatically by Rubicon when the corresponding Python object is deallocated.
         """
         self._needs_release = False
         send_message(self, "release", restype=objc_id, argtypes=[])

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -661,7 +661,7 @@ class ObjCInstance(object):
         # We use autorelease instead of release here to prevent instances without a Python
         # reference but with an Obj-C reference from being released too early.
         if self._needs_release and self.objc_class.name != 'NSAutoreleasePool':
-            self.autorelease()
+            send_message(self, "autorelease", restype=objc_id, argtypes=[])
 
     def __str__(self):
         """Get a human-readable representation of ``self``.

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -683,7 +683,7 @@ class ObjCInstance(object):
         """
         Release the corresponding objc instance if we own it, i.e., if it was returned by
         by a method starting with 'alloc', 'new', 'copy', or 'mutableCopy' and it wasn't
-        already explicitly released by calling :meth:`release`.
+        already explicitly released by calling :meth:`release` or :meth:`autorelease`.
         """
 
         if self._needs_release:

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -667,6 +667,17 @@ class ObjCInstance(object):
         self._needs_release = False
         send_message(self, "release", restype=objc_id, argtypes=[])
 
+    def autorelease(self):
+        """
+        Decrements the receiver’s reference count at the end of the current autorelease pool block
+
+        The objc object is sent a dealloc message when its reference count reaches 0. If called,
+        the object will not be released when the Python object is deallocated.
+        """
+        self._needs_release = False
+        result = send_message(self, "autorelease", restype=objc_id, argtypes=[])
+        return ObjCInstance(result)
+
     def __del__(self):
         """
         Release the corresponding objc instance if we own it, i.e., if it was returned by

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -167,7 +167,7 @@ class ObjCMethod(object):
 
         # Mark for release if we acquire ownership of an object. Do not autorelease here because
         # we might retain a Python reference while the Obj-C reference goes out of scope.
-        if any(self.name.startswith(prefix) for prefix in (b'alloc', b'new', b'copy', b'mutableCopy')):
+        if self.name.startswith((b'alloc', b'new', b'copy', b'mutableCopy')):
             result._needs_release = True
 
         return result

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -656,17 +656,6 @@ class ObjCInstance(object):
 
         return self
 
-    def retain(self):
-        """
-        Manually increment the reference count of the corresponding objc object
-
-        The objc object is sent a dealloc message when its reference count reaches 0.
-        Use this method to retain objects which we don't own.
-        """
-        self._needs_release = True
-        result = send_message(self, "retain", restype=objc_id, argtypes=[])
-        return ObjCInstance(result)
-
     def release(self):
         """
         Manually decrement the reference count of the corresponding objc object

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -657,6 +657,11 @@ class ObjCInstance(object):
         return self
 
     def __del__(self):
+        """
+        Release the corresponding objc instance if we own it, i.e., if it was returned by
+        by a method starting with 'alloc', 'new', 'copy', or 'mutableCopy' and it wasn't
+        already explicitly released by calling :meth:`release`.
+        """
 
         if self._needs_release:
             send_message(self, "release", restype=objc_id, argtypes=[])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -167,7 +167,7 @@ class RubiconTest(unittest.TestCase):
         random_obj = NSObject.alloc().init()
         with self.assertRaises(ValueError):
             ObjCClass(random_obj.ptr)
-        random_obj.release()
+        del random_obj  # will release random_obj
 
     def test_objcmetaclass_requires_metaclass(self):
         """ObjCMetaClass only accepts metaclass pointers."""
@@ -175,7 +175,8 @@ class RubiconTest(unittest.TestCase):
         random_obj = NSObject.alloc().init()
         with self.assertRaises(ValueError):
             ObjCMetaClass(random_obj.ptr)
-        random_obj.release()
+
+        del random_obj  # will release random_obj
 
         with self.assertRaises(ValueError):
             ObjCMetaClass(NSObject.ptr)
@@ -186,7 +187,8 @@ class RubiconTest(unittest.TestCase):
         random_obj = NSObject.alloc().init()
         with self.assertRaises(ValueError):
             ObjCProtocol(random_obj.ptr)
-        random_obj.release()
+
+        del random_obj  # will release random_obj
 
     def test_objcclass_superclass(self):
         """An ObjCClass's superclass can be looked up."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -167,7 +167,6 @@ class RubiconTest(unittest.TestCase):
         random_obj = NSObject.alloc().init()
         with self.assertRaises(ValueError):
             ObjCClass(random_obj.ptr)
-        del random_obj  # will release random_obj
 
     def test_objcmetaclass_requires_metaclass(self):
         """ObjCMetaClass only accepts metaclass pointers."""
@@ -175,8 +174,6 @@ class RubiconTest(unittest.TestCase):
         random_obj = NSObject.alloc().init()
         with self.assertRaises(ValueError):
             ObjCMetaClass(random_obj.ptr)
-
-        del random_obj  # will release random_obj
 
         with self.assertRaises(ValueError):
             ObjCMetaClass(NSObject.ptr)
@@ -187,8 +184,6 @@ class RubiconTest(unittest.TestCase):
         random_obj = NSObject.alloc().init()
         with self.assertRaises(ValueError):
             ObjCProtocol(random_obj.ptr)
-
-        del random_obj  # will release random_obj
 
     def test_objcclass_superclass(self):
         """An ObjCClass's superclass can be looked up."""


### PR DESCRIPTION
This PR aims to fix #200 and #48 by autoreleasing any obj-c instances which we own (created with a method which starts with "alloc", "copy", "mutableCopy", or "new").

The implementation goes as follows:

1. When an object is returned from a objc method call which qualifies, the object is marked with `_needs_release = True`.
2. Just before the Python instance is deleted, autorelease is called on the objc instance.

I've opted to use `autorelease` instead of `release` because the latter would result in occasional segfaults when the objc-instance is still needed while the Python instance has been destroyed. This is the case for some attributes of the cell views in a `toga.Table`.

Similarly, `autorelease` is not called directly when the instance is created because this would result in some Python variables pointing to a released objc instance.

@dgelessus, is this in line with what you envisioned? The workaround with the `_needs_release` is a bit of a hack but it seems necessary to me because `ObjCInstance` itself does not know which method created it. Any better ideas are welcome!

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
