### PR TITLE
Schedule callback for signal handler in CFRunLoop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
   # minutes on macOS 10.11.
   - pyenv install --skip-existing 3.5.2
   - pyenv global 3.5.2
-  - python -m pip install --upgrade pip
+  - python -m pip install --upgrade "pip<21"
   - python -m pip install --upgrade setuptools
   - python -m pip install tox
 script:

--- a/changes/202.bugfix.rst
+++ b/changes/202.bugfix.rst
@@ -1,0 +1,1 @@
+Fix calling of signal handlers added to the asyncio loop with CFRunLoop integration.

--- a/rubicon/objc/eventloop.py
+++ b/rubicon/objc/eventloop.py
@@ -540,6 +540,17 @@ class CFEventLoop(unix_events.SelectorEventLoop):
             args=args
         )
 
+    def _handle_signal(self, sig):
+        """Internal helper that is the actual signal handler."""
+
+        handle = self._signal_handlers.get(sig)
+        if handle is None:
+            return  # Assume it's some race condition.
+        if handle._cancelled:
+            self.remove_signal_handler(sig)  # Remove it properly.
+        else:
+            self.call_soon(handle._callback)
+
     def time(self):
         """Return the time according to the event loop's clock.
 


### PR DESCRIPTION
This PR fixes #202 by scheduling any callbacks on signals to run in the CFRunLoop. 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
