### PR TITLE
Allow restarting a stopped asyncio event loop.

### DIFF
--- a/changes/205.bugfix.rst
+++ b/changes/205.bugfix.rst
@@ -1,0 +1,1 @@
+Allow restarting a stopped event loop.

--- a/rubicon/objc/eventloop.py
+++ b/rubicon/objc/eventloop.py
@@ -444,7 +444,8 @@ class CFEventLoop(unix_events.SelectorEventLoop):
 
     def run_forever(self, lifecycle=None):
         """Run until stop() is called."""
-        self._set_lifecycle(lifecycle if lifecycle else CFLifecycle(self._cfrunloop))
+        if not self._lifecycle:
+            self._set_lifecycle(lifecycle if lifecycle else CFLifecycle(self._cfrunloop))
 
         if self.is_running():
             raise RuntimeError(
@@ -467,7 +468,8 @@ class CFEventLoop(unix_events.SelectorEventLoop):
         The implementation is effectively all the parts of a call to
         :meth:`run_forever()`, but without any of the shutdown/cleanup logic.
         """
-        self._set_lifecycle(lifecycle if lifecycle else CFLifecycle(self._cfrunloop))
+        if not self._lifecycle:
+            self._set_lifecycle(lifecycle if lifecycle else CFLifecycle(self._cfrunloop))
 
         if self.is_running():
             raise RuntimeError(


### PR DESCRIPTION
This PR fixes #204 by not setting the asyncio loop lifecycle again when it has already been set.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
