### PR TITLE
Replace links to Gitter with Discord

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ dist
 build
 _build
 distribute-*
-env
+venv*/
 local
 .tox
 

--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ Rubicon is part of the `BeeWare suite`_. You can talk to the community through:
 * `Discord <https://discord.com/channels/836455665257021440/836455665257021443>`__
   (`Click here for an invitation to the server <https://beeware.org/bee/chat/>`__)
 
-* The Toga `Github Discussions forum <https://github.com/beeware/rubicon-objc/discussions>`__
+* The Rubicon-ObjC `Github Discussions forum <https://github.com/beeware/rubicon-objc/discussions>`__
 
 Code of Conduct
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -72,8 +72,7 @@ Rubicon is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter <https://twitter.com/pybeeware>`__
 
-* `Discord <https://discord.com/channels/836455665257021440/836455665257021443>`__
-  (`Click here for an invitation to the server <https://beeware.org/bee/chat/>`__)
+* `Discord <https://beeware.org/bee/chat/>`__
 
 * The Rubicon-ObjC `Github Discussions forum <https://github.com/beeware/rubicon-objc/discussions>`__
 

--- a/README.rst
+++ b/README.rst
@@ -25,9 +25,9 @@ Rubicon-ObjC
    :target: https://github.com/beeware/rubicon-objc/actions
    :alt: Build Status
 
-.. image:: https://badges.gitter.im/beeware/general.svg
-   :target: https://gitter.im/beeware/general
-   :alt: Gitter chat room
+.. image:: https://img.shields.io/discord/836455665257021440?label=Discord%20Chat&logo=discord&style=plastic
+   :target: https://beeware.org/bee/chat/
+   :alt: Discord server
 
 Rubicon-ObjC is a bridge between Objective-C and Python. It enables you to:
 
@@ -70,9 +70,12 @@ Community
 
 Rubicon is part of the `BeeWare suite`_. You can talk to the community through:
 
-* `@pybeeware on Twitter`_
+* `@pybeeware on Twitter <https://twitter.com/pybeeware>`__
 
-* The `beeware/general`_ channel on Gitter.
+* `Discord <https://discord.com/channels/836455665257021440/836455665257021443>`__
+  (`Click here for an invitation to the server <https://beeware.org/bee/chat/>`__)
+
+* The Toga `Github Discussions forum <https://github.com/beeware/rubicon-objc/discussions>`__
 
 Code of Conduct
 ---------------
@@ -92,8 +95,6 @@ want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
 .. _BeeWare suite: https://beeware.org
 .. _Read The Docs: https://rubicon-objc.readthedocs.org
-.. _@pybeeware on Twitter: https://twitter.com/pybeeware
-.. _beeware/general: https://gitter.im/beeware/general
 .. _Code of Conduct: https://beeware.org/community/behavior/
 .. _log them on GitHub: https://github.com/beeware/rubicon-objc/issues
 .. _fork the code: https://github.com/beeware/rubicon-objc

--- a/changes/208.misc.rst
+++ b/changes/208.misc.rst
@@ -1,0 +1,1 @@
+Community chat was moved to Discord.

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,15 @@ include =
 
 [flake8]
 # https://flake8.readthedocs.org/en/latest/
-exclude=*.egg-info/*,.git/*,.tox/*,__pycache__,build/*,docs/*,env/*
+exclude=
+    *.egg-info/*
+    .git/*
+    .tox/*
+    __pycache__
+    build/*
+    docs/*
+    venv*/*
+
 max-complexity = 20
 max-line-length = 119
 


### PR DESCRIPTION
* Replaces links to Gitter with the new Discord rooms
* Updates the gitignore and flake8 config to ignore virtual environment folders.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
