### PR TITLE
Replace deallocation observer

### DIFF
--- a/changes/209.feature.rst
+++ b/changes/209.feature.rst
@@ -1,0 +1,1 @@
+Improved memory management when a Python instance is assigned to a new ObjCInstance attribute.


### PR DESCRIPTION
This PR closes #185 by replacing the deallocation observer mechanism. Its still work in progress but I am posting here because I'd like some feedback from @dgelessus on a couple of questions.

The mechanism for handling new attributes with Python instances as values is as follows:

1. When the Python instance `pyo` is assigned through `__setattr__`, a new `WrappedPyObject` is created to "wrap" that object. Practically, the `WrappedPyObject` manually increments the refcount of `pyo` and stores the address to `pyo` in an ivar.
2. This `WrappedPyObject` is associated with the original ObjCInstance through `objc_setAssociatedObject` which holds the only reference to it. The lifecycles of the ObjCInstance and the `WrappedPyObject` are therefore tied together.
3. When the ObjCInstance is deallocated, so is the `WrappedPyObject`. This will cause the refcount of `pyo` to be decremented in the overridden `WrappedPyObject.dealloc` method.

I've also updated the tests to ensure that all Python objects are indeed destroyed when they should be. This has been working quite well in my manual testing but I am still uncertain about a couple of implementation details. The questions are inline.

A larger question is regarding performance. Creating a new `WrappedPyObject` for each instance attribute can potentially be costly. But I don't really see an easy way around that. What do you think?

Edit: @freakboy3742 is of course also very welcome to comment!

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
