### PR TITLE
Allow declaring weak properties

### DIFF
--- a/changes/210.feature.rst
+++ b/changes/210.feature.rst
@@ -1,0 +1,1 @@
+Added support to declare weak properties on custom Objective-C classes.

--- a/docs/reference/rubicon-objc-runtime.rst
+++ b/docs/reference/rubicon-objc-runtime.rst
@@ -169,7 +169,7 @@ These utility functions provide easier access from Python to certain parts of th
 .. autofunction:: should_use_fpret
 .. autofunction:: send_message
 .. autofunction:: send_super
-.. autofunction:: add_method
+.. autofunction:: replace_method
 .. autofunction:: add_ivar
 .. autofunction:: get_ivar
 .. autofunction:: set_ivar

--- a/docs/reference/rubicon-objc-runtime.rst
+++ b/docs/reference/rubicon-objc-runtime.rst
@@ -169,7 +169,7 @@ These utility functions provide easier access from Python to certain parts of th
 .. autofunction:: should_use_fpret
 .. autofunction:: send_message
 .. autofunction:: send_super
-.. autofunction:: replace_method
+.. autofunction:: add_method
 .. autofunction:: add_ivar
 .. autofunction:: get_ivar
 .. autofunction:: set_ivar

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -1008,8 +1008,12 @@ class ObjCClass(ObjCInstance, type):
 
             # Invoke dealloc callback of each property.
             for attr_name, obj in attrs.items():
-                if isinstance(obj, objc_property):
-                    obj.dealloc_callback(objc_self, attr_name)
+                try:
+                    dealloc_callback = obj.dealloc_callback
+                except AttributeError:
+                    pass
+                else:
+                    dealloc_callback(objc_self, attr_name)
 
             # Invoke original dealloc.
             cfunctype = CFUNCTYPE(None, objc_id, SEL)

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -454,8 +454,7 @@ class objc_property(object):
             # Clean up ivar.
             if self.weak:
                 # Clean up weak reference.
-                ivar = libobjc.class_getInstanceVariable(libobjc.object_getClass(objc_self), ivar_name.encode())
-                libobjc.objc_storeWeak(objc_self.value + libobjc.ivar_getOffset(ivar), None)
+                set_ivar(objc_self, ivar_name, self.vartype(None), weak=True)
             elif issubclass(self.vartype, objc_id):
                 # If the old value is a non-null object, release it. There is no need to set the actual ivar to nil.
                 old_value = get_ivar(objc_self, ivar_name, weak=self.weak)

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -1023,7 +1023,7 @@ class ObjCClass(ObjCInstance, type):
                     dealloc_callback(objc_self, attr_name)
 
             # Invoke super dealloc.
-            send_super(ptr, objc_self, "dealloc", restype=None, argtypes=[])
+            send_super(ptr, objc_self, "dealloc", restype=None, argtypes=[], _allow_dealloc=True)
 
         add_method(ptr, "dealloc", _new_delloc, [None, ObjCInstance, SEL])
 

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -13,7 +13,7 @@ from .types import (
     register_ctype_for_type
 )
 from .runtime import (
-    Class, SEL, add_ivar, replace_method, ensure_bytes, get_class, get_ivar, libc, libobjc, objc_block, objc_id,
+    Class, SEL, add_ivar, add_method, ensure_bytes, get_class, get_ivar, libc, libobjc, objc_block, objc_id,
     objc_property_attribute_t, object_isClass, set_ivar, send_message, send_super,
 )
 
@@ -279,7 +279,7 @@ class objc_method(object):
 
     def class_register(self, class_ptr, attr_name):
         name = attr_name.replace("_", ":")
-        replace_method(class_ptr, name, self, self.encoding)
+        add_method(class_ptr, name, self, self.encoding)
 
     def protocol_register(self, proto_ptr, attr_name):
         name = attr_name.replace('_', ':')
@@ -315,7 +315,7 @@ class objc_classmethod(object):
 
     def class_register(self, class_ptr, attr_name):
         name = attr_name.replace("_", ":")
-        replace_method(libobjc.object_getClass(class_ptr), name, self, self.encoding)
+        add_method(libobjc.object_getClass(class_ptr), name, self, self.encoding)
 
     def protocol_register(self, proto_ptr, attr_name):
         name = attr_name.replace('_', ':')
@@ -433,11 +433,11 @@ class objc_property(object):
 
         setter_name = 'set' + attr_name[0].upper() + attr_name[1:] + ':'
 
-        replace_method(
+        add_method(
             class_ptr, attr_name, _objc_getter,
             [self.vartype, ObjCInstance, SEL],
         )
-        replace_method(
+        add_method(
             class_ptr, setter_name, _objc_setter,
             [None, ObjCInstance, SEL, self.vartype],
         )
@@ -466,7 +466,7 @@ class objc_property(object):
             old_dealloc_callable = cast(old_dealloc, cfunctype)
             old_dealloc_callable(objc_self, SEL("dealloc"))
 
-        replace_method(class_ptr, 'dealloc', _new_delloc, [None, ObjCInstance, SEL])
+        add_method(class_ptr, 'dealloc', _new_delloc, [None, ObjCInstance, SEL], replace=True)
 
     def protocol_register(self, proto_ptr, attr_name):
         attrs = self._get_property_attributes()
@@ -501,7 +501,7 @@ class objc_rawmethod(object):
 
     def class_register(self, class_ptr, attr_name):
         name = attr_name.replace("_", ":")
-        replace_method(class_ptr, name, self, self.encoding)
+        add_method(class_ptr, name, self, self.encoding)
 
     def protocol_register(self, proto_ptr, attr_name):
         raise TypeError('Protocols cannot have method implementations, use objc_method instead of objc_rawmethod')

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -13,7 +13,7 @@ from .types import (
     register_ctype_for_type
 )
 from .runtime import (
-    Class, SEL, add_ivar, add_method, ensure_bytes, get_class, get_ivar, libc, libobjc, objc_block, objc_id,
+    Class, SEL, add_ivar, replace_method, ensure_bytes, get_class, get_ivar, libc, libobjc, objc_block, objc_id,
     objc_property_attribute_t, object_isClass, set_ivar, send_message, send_super,
 )
 
@@ -279,7 +279,7 @@ class objc_method(object):
 
     def class_register(self, class_ptr, attr_name):
         name = attr_name.replace("_", ":")
-        add_method(class_ptr, name, self, self.encoding)
+        replace_method(class_ptr, name, self, self.encoding)
 
     def protocol_register(self, proto_ptr, attr_name):
         name = attr_name.replace('_', ':')
@@ -315,7 +315,7 @@ class objc_classmethod(object):
 
     def class_register(self, class_ptr, attr_name):
         name = attr_name.replace("_", ":")
-        add_method(libobjc.object_getClass(class_ptr), name, self, self.encoding)
+        replace_method(libobjc.object_getClass(class_ptr), name, self, self.encoding)
 
     def protocol_register(self, proto_ptr, attr_name):
         name = attr_name.replace('_', ':')
@@ -430,11 +430,11 @@ class objc_property(object):
 
         setter_name = 'set' + attr_name[0].upper() + attr_name[1:] + ':'
 
-        add_method(
+        replace_method(
             class_ptr, attr_name, _objc_getter,
             [self.vartype, ObjCInstance, SEL],
         )
-        add_method(
+        replace_method(
             class_ptr, setter_name, _objc_setter,
             [None, ObjCInstance, SEL, self.vartype],
         )
@@ -475,7 +475,7 @@ class objc_rawmethod(object):
 
     def class_register(self, class_ptr, attr_name):
         name = attr_name.replace("_", ":")
-        add_method(class_ptr, name, self, self.encoding)
+        replace_method(class_ptr, name, self, self.encoding)
 
     def protocol_register(self, proto_ptr, attr_name):
         raise TypeError('Protocols cannot have method implementations, use objc_method instead of objc_rawmethod')

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -18,7 +18,7 @@ __all__ = [
     'Method',
     'SEL',
     'add_ivar',
-    'add_method',
+    'replace_method',
     'get_class',
     'get_ivar',
     'libc',
@@ -301,7 +301,7 @@ libobjc.class_isMetaClass.argtypes = [Class]
 
 # IMP class_replaceMethod(Class cls, SEL name, IMP imp, const char *types)
 libobjc.class_replaceMethod.restype = IMP
-libobjc.class_replaceMethod.argtypes = [Class, SEL, Ivar, c_char_p]
+libobjc.class_replaceMethod.argtypes = [Class, SEL, IMP, c_char_p]
 
 # BOOL class_respondsToSelector(Class cls, SEL sel)
 libobjc.class_respondsToSelector.restype = c_bool
@@ -858,8 +858,8 @@ def send_super(cls, receiver, selector, *args, restype=c_void_p, argtypes=None):
 _keep_alive_imps = []
 
 
-def add_method(cls, selector, method, encoding):
-    """Add a new instance method to the given class.
+def replace_method(cls, selector, method, encoding):
+    """Add a new instance method to the given class or replace an existing instance method.
 
     To add a class method, add an instance method to the metaclass.
 
@@ -886,7 +886,7 @@ def add_method(cls, selector, method, encoding):
 
     cfunctype = CFUNCTYPE(*signature)
     imp = cfunctype(method)
-    libobjc.class_addMethod(cls, selector, cast(imp, IMP), types)
+    libobjc.class_replaceMethod(cls, selector, cast(imp, IMP), types)
     _keep_alive_imps.append(imp)
     return imp
 

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -924,7 +924,7 @@ def get_ivar(obj, varname, weak=False):
     if weak:
         value = libobjc.objc_loadWeakRetained(obj.value + libobjc.ivar_getOffset(ivar))
         return libobjc.objc_autoreleaseReturnValue(value)
-    elif isinstance(vartype, objc_id):
+    elif issubclass(vartype, objc_id):
         return cast(libobjc.object_getIvar(obj, ivar), vartype)
     else:
         return vartype.from_address(obj.value + libobjc.ivar_getOffset(ivar))
@@ -957,7 +957,7 @@ def set_ivar(obj, varname, value, weak=False):
 
     if weak:
         libobjc.objc_storeWeak(obj.value + libobjc.ivar_getOffset(ivar), value)
-    elif isinstance(vartype, objc_id):
+    elif issubclass(vartype, objc_id):
         libobjc.object_setIvar(obj, ivar, value)
     else:
         memmove(obj.value + libobjc.ivar_getOffset(ivar), addressof(value), sizeof(vartype))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1003,6 +1003,47 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(r.size.width, 56)
         self.assertEqual(r.size.height, 78)
 
+    def test_class_properties_lifecycle_strong(self):
+
+        class StrongProperties(NSObject):
+            object = objc_property(ObjCInstance)
+
+        pool = NSAutoreleasePool.alloc().init()
+
+        properties = StrongProperties.alloc().init()
+
+        obj = NSObject.alloc().init()
+        obj_pointer = obj.ptr.value  # store the object pointer for future use
+
+        properties.object = obj
+
+        del obj
+        del pool
+        gc.collect()
+
+        # assert that the object was retained by the property
+        self.assertEqual(properties.object.ptr.value, obj_pointer)
+
+    def test_class_properties_lifecycle_weak(self):
+
+        class WeakProperties(NSObject):
+            object = objc_property(ObjCInstance, weak=True)
+
+        pool = NSAutoreleasePool.alloc().init()
+
+        properties = WeakProperties.alloc().init()
+
+        obj = NSObject.alloc().init()
+        properties.object = obj
+
+        self.assertIs(properties.object, obj)
+
+        del obj
+        del pool
+        gc.collect()
+
+        self.assertIsNone(properties.object)
+
     def test_class_with_wrapped_methods(self):
         """An ObjCClass can have wrapped methods."""
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1359,3 +1359,32 @@ class RubiconTest(unittest.TestCase):
         # Delete it and make sure that we don't segfault on garbage collection.
         del string
         gc.collect()
+
+    def test_objcinstance_dealloc(self):
+
+        class DeallocTester(NSObject):
+            attr0 = objc_property()
+            attr1 = objc_property(weak=True)
+
+            @objc_method
+            def dealloc(self):
+                self._did_dealloc = True
+
+        obj = DeallocTester.alloc().init()
+        obj.__dict__["_did_dealloc"] = False
+
+        attr0 = NSObject.alloc().init()
+        attr1 = NSObject.alloc().init()
+
+        obj.attr0 = attr0
+        obj.attr1 = attr1
+
+        self.assertEqual(attr0.retainCount(), 2)
+        self.assertEqual(attr1.retainCount(), 1)
+
+        # ObjC object will be deallocated, can only access Python attributes afterwards.
+        obj.release()
+
+        self.assertTrue(obj._did_dealloc, "custom dealloc did not run")
+        self.assertEqual(attr0.retainCount(), 1, "strong property value was not released")
+        self.assertEqual(attr1.retainCount(), 1, "weak property value was released")


### PR DESCRIPTION
This PR adds support for declaring weak properties when creating custom Objective-C classes.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
