### PR TITLE
Autoreleasepool context manager

### DIFF
--- a/changes/213.feature.rst
+++ b/changes/213.feature.rst
@@ -1,0 +1,1 @@
+Added `autoreleasepool` context manager to mimic Objective-C `@autoreleasepool` blocks.

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -20,6 +20,7 @@ __all__ = [
     'SEL',
     'add_ivar',
     'add_method',
+    'autoreleasepool',
     'get_class',
     'get_ivar',
     'libc',
@@ -361,6 +362,14 @@ libobjc.method_setImplementation.argtypes = [Method, IMP]
 # Class objc_allocateClassPair(Class superclass, const char *name, size_t extraBytes)
 libobjc.objc_allocateClassPair.restype = Class
 libobjc.objc_allocateClassPair.argtypes = [Class, c_char_p, c_size_t]
+
+# void *objc_autoreleasePoolPush(void)
+libobjc.objc_autoreleasePoolPush.restype = c_void_p
+libobjc.objc_autoreleasePoolPush.argtypes = []
+
+# void objc_autoreleasePoolPop(void *pool)
+libobjc.objc_autoreleasePoolPop.restype = None
+libobjc.objc_autoreleasePoolPop.argtypes = [c_void_p]
 
 # id objc_autoreleaseReturnValue(id value)
 libobjc.objc_autoreleaseReturnValue.restype = objc_id
@@ -981,3 +990,23 @@ def set_ivar(obj, varname, value, weak=False):
         libobjc.object_setIvar(obj, ivar, value)
     else:
         memmove(obj.value + libobjc.ivar_getOffset(ivar), addressof(value), sizeof(vartype))
+
+
+class autoreleasepool:
+    """
+    A context manager that has the same effect as a @autoreleasepool block in Objective-C.
+
+    Any objects that are autoreleased within the context will receive a release message when exiting the context. When
+    running an event loop, AppKit will create an autorelease pool at the beginning of each cycle of the event loop and
+    drain it at the end. You therefore do not need to use @autoreleasepool blocks when running an event loop. However,
+    they may be still be useful when your code temporarily allocates large amounts of memory which you want to
+    explicitly free before the end of a cycle.
+    """
+    def __init__(self):
+        self.pool = None
+
+    def __enter__(self):
+        self.pool = libobjc.objc_autoreleasePoolPush()
+
+    def __exit__(self, type, value, traceback):
+        libobjc.objc_autoreleasePoolPop(self.pool)


### PR DESCRIPTION
This PR adds an `autoreleasepool` context manager to `rubicon.obj.runtime` which mimics Objective-C's `@autoreleasepool` blocks. Closes #210.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
