### PR TITLE
Store Python objects in Objective-C properties

### DIFF
--- a/changes/214.feature.rst
+++ b/changes/214.feature.rst
@@ -1,0 +1,1 @@
+Allow storing Python objects in Objective-C properties declared with `objc_property`.

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -386,7 +386,7 @@ class objc_property(object):
 
         self.weak = weak
 
-        self._is_pyo = self.vartype is py_object
+        self._is_pyo = issubclass(self.vartype, py_object)
         self._is_objc = issubclass(self.vartype, objc_id)
 
     def _get_property_attributes(self):

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -453,7 +453,7 @@ class objc_property(object):
 
             if self._is_py_object:
                 # Retain the Python object in dictionary, this replaces any previous entry for this property.
-                _keep_alive_objects[self] = new_value.value
+                _keep_alive_objects[(objc_self.value, self)] = new_value.value
 
             set_ivar(objc_self, ivar_name, new_value, weak=self._ivar_weak)
 
@@ -490,7 +490,7 @@ class objc_property(object):
 
         # Remove any Python objects that are kept alive.
         try:
-            del _keep_alive_objects[self]
+            del _keep_alive_objects[(objc_self.value, self)]
         except KeyError:
             pass
 

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -408,6 +408,15 @@ class objc_property(object):
 
         add_ivar(class_ptr, ivar_name, self.vartype)
 
+        # Implementation note:
+        # 1. Objective-C objects are stored as strong or weak references in the ivar if the property was declared as
+        #    strong or weak, respectively. In case of strong properties, we retain the object when storing it in the
+        #    ivar and release it when the ivar is changed.
+        # 2. Python objects are wrapped as `ctypes.py_object` which are then always stored as a strong reference in
+        #    the ivar. Since this does not increase the reference count of the Python object itself, we keep a
+        #    reference to it in `_keep_alive_objects`. For weak properties, we store a Python `wearef` to the object
+        #    instead. This weakref is similarly kept alive.
+
         def _objc_getter(objc_self, _cmd):
             value = get_ivar(objc_self, ivar_name, weak=self._ivar_weak)
 

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -497,10 +497,7 @@ class objc_property(object):
             send_message(old_value, 'release', restype=None, argtypes=[])
 
         # Remove any Python objects that are kept alive.
-        try:
-            del _keep_alive_objects[(objc_self.value, self)]
-        except KeyError:
-            pass
+        _keep_alive_objects.pop((objc_self.value, self), None)
 
     def protocol_register(self, proto_ptr, attr_name):
         attrs = self._get_property_attributes()

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -451,9 +451,9 @@ class objc_property(object):
                     # Retain the object on the Objective-C side.
                     send_message(new_value, 'retain', restype=objc_id, argtypes=[])
 
-                elif self._is_py_object:
-                    # Retain the Python object in dictionary, this replaces any previous entry for this property.
-                    _keep_alive_objects[self] = new_value.value
+            if self._is_py_object:
+                # Retain the Python object in dictionary, this replaces any previous entry for this property.
+                _keep_alive_objects[self] = new_value.value
 
             set_ivar(objc_self, ivar_name, new_value, weak=self._ivar_weak)
 

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -51,6 +51,11 @@ __all__ = [
     'unregister_type_for_objcclass',
 ]
 
+# Dictionary to keep references to Python objects which are stored in declared
+# properties or dynamically created attributes of Objective-C objects. This ensures that
+# the Python objects are not destroyed if they are otherwise no Python references left.
+_keep_alive_objects = {}
+
 
 def encoding_from_annotation(f, offset=1):
     argspec = inspect.getfullargspec(inspect.unwrap(f))
@@ -1632,13 +1637,6 @@ NSObjectProtocol = ObjCProtocol('NSObject')
 # This allows reloading the module without having to restart
 # the interpreter, although any changes to WrappedPyObject
 # itself are only applied after a restart of course.
-
-
-# Dictionary to keep references to wrapped Python objects. This prevents them
-# from being collected if there are otherwise only Objective-C references left
-# to the object.
-_keep_alive_objects = {}
-
 
 try:
     WrappedPyObject = ObjCClass("WrappedPyObject")

--- a/rubicon/objc/types.py
+++ b/rubicon/objc/types.py
@@ -88,6 +88,7 @@ _ctype_for_type_map = {
     float: c_double,
     bool: c_bool,
     bytes: c_char_p,
+    object: py_object,
 }
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1006,6 +1006,20 @@ class RubiconTest(unittest.TestCase):
         gc.collect()
         self.assertIsNone(wr())
 
+        # Test that Python object is released by dealloc.
+
+        o = PythonObject()
+        wr = weakref.ref(o)
+
+        properties.object = o
+        self.assertIs(properties.object, o)
+
+        del o
+        del properties
+        gc.collect()
+
+        self.assertIsNone(wr())
+
     def test_class_python_properties_weak(self):
 
         class WeakPythonObjectProperties(NSObject):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1003,6 +1003,7 @@ class RubiconTest(unittest.TestCase):
 
         # Test that Python object is released by the property.
         properties.object = None
+        gc.collect()
         self.assertIsNone(wr())
 
     def test_class_python_properties_weak(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -977,6 +977,59 @@ class RubiconTest(unittest.TestCase):
         box.data = None
         self.assertIsNone(box.data)
 
+    def test_class_python_properties(self):
+
+        class PythonObjectProperties(NSObject):
+            object = objc_property(object)
+
+        class PythonObject:
+            pass
+
+        properties = PythonObjectProperties.alloc().init()
+
+        o = PythonObject()
+        wr = weakref.ref(o)
+
+        properties.object = o
+
+        # Test that Python object is properly stored.
+        self.assertIs(properties.object, o)
+
+        # Test that Python object is retained by the property.
+        del o
+        gc.collect()
+
+        self.assertIs(properties.object, wr())
+
+        # Test that Python object is released by the property.
+        properties.object = None
+        self.assertIsNone(wr())
+
+    def test_class_python_properties_weak(self):
+
+        class WeakPythonObjectProperties(NSObject):
+            object = objc_property(object, weak=True)
+
+        class PythonObject:
+            pass
+
+        properties = WeakPythonObjectProperties.alloc().init()
+
+        o = PythonObject()
+        wr = weakref.ref(o)
+
+        properties.object = o
+
+        # Test that Python object is properly stored.
+        self.assertIs(properties.object, o)
+
+        # Test that Python object is not retained by the property.
+        del o
+        gc.collect()
+
+        self.assertIsNone(properties.object)
+        self.assertIsNone(wr())
+
     def test_class_nonobject_properties(self):
         """An Objective-C class can have properties of non-object types."""
 


### PR DESCRIPTION
This PR enables storing Python objects in Objective-C properties. Since properties are declared before the class is instantiated, we do not need to resort to any trickery with associated objects to store them. Instead, we store them in the ivar, just like other property values. In practice, this is done as follows:

1. Added `object` -> `ctypes.py_object` to the `ctype_for_type` map. This allows us to store an actual `ctypes.py_object` as the ivar value. Interestingly, you already had the proper encoding `b"^{_object=i^{_typeobject}}"` registered for `py_object`.
2. For a strong reference: Store the python object as a `py_object` in a strong property. Increase the reference count on the Python side by keeping a reference in `_keep_alive_objects`.
3. For a weak reference: wrap it in a Python `weakref`. Store this weakref in a strong property and don't keep a reference in `_keep_alive_objects`. When we retrieve the value, unpack the weakref.

This approach is a bit convoluted so I have marked the PR as WIP to get some initial feedback. Any ideas for simplification are very welcome. Especially the setter for the property value is becoming a maze of if-else statements. We could for example define different setters instead and move the if-else logic to the outside.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
