### PR TITLE
Enforce object type for weak properties

### DIFF
--- a/changes/215.bugfix.rst
+++ b/changes/215.bugfix.rst
@@ -1,0 +1,1 @@
+Raise `TypeError` when trying to declare a weak property of a non-object type.

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -394,7 +394,10 @@ class objc_property(object):
         self._ivar_weak = self.weak and not self._is_py_object
 
         if self.weak and not (self._is_py_object or self._is_objc_object):
-            raise TypeError("Weak properties are only supported for Objective-C or Python object types")
+            raise TypeError(
+                "Incompatible type for ivar {!r}: Weak properties are only supported "
+                "for Objective-C or Python object types".format(vartype)
+            )
 
     def _get_property_attributes(self):
         attrs = [

--- a/rubicon/objc/api.py
+++ b/rubicon/objc/api.py
@@ -376,7 +376,7 @@ class objc_property(object):
 
     If ``weak`` is ``True``, the property will be created as a weak property. When assigning an object to it,
     the reference count of the object will not be increased. When the object is deallocated, the property
-    value is set to None.
+    value is set to None. Weak properties are only supported for Objective-C or Python object types.
     """
 
     def __init__(self, vartype=objc_id, weak=False):
@@ -392,6 +392,9 @@ class objc_property(object):
         # Weakly referenced Python objects are still stored in strong ivars.
         # Check here if we need a weak or strong ivar.
         self._ivar_weak = self.weak and not self._is_py_object
+
+        if self.weak and not (self._is_py_object or self._is_objc_object):
+            raise TypeError("Weak properties are only supported for Objective-C or Python object types")
 
     def _get_property_attributes(self):
         attrs = [

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1048,12 +1048,12 @@ class RubiconTest(unittest.TestCase):
     def test_class_nonobject_properties(self):
         """An Objective-C class can have properties of non-object types."""
 
-        class Properties(NSObject):
+        class NonObjectProperties(NSObject):
             object = objc_property(ObjCInstance)
             int = objc_property(c_int)
             rect = objc_property(NSRect)
 
-        properties = Properties.alloc().init()
+        properties = NonObjectProperties.alloc().init()
 
         properties.object = at('foo')
         properties.int = 12345
@@ -1076,12 +1076,12 @@ class RubiconTest(unittest.TestCase):
 
     def test_class_properties_lifecycle_strong(self):
 
-        class StrongProperties(NSObject):
+        class StrongObjectProperties(NSObject):
             object = objc_property(ObjCInstance)
 
         with autoreleasepool():
 
-            properties = StrongProperties.alloc().init()
+            properties = StrongObjectProperties.alloc().init()
 
             obj = NSObject.alloc().init()
             obj_pointer = obj.ptr.value  # store the object pointer for future use
@@ -1096,12 +1096,12 @@ class RubiconTest(unittest.TestCase):
 
     def test_class_properties_lifecycle_weak(self):
 
-        class WeakProperties(NSObject):
+        class WeakObjectProperties(NSObject):
             object = objc_property(ObjCInstance, weak=True)
 
         with autoreleasepool():
 
-            properties = WeakProperties.alloc().init()
+            properties = WeakObjectProperties.alloc().init()
 
             obj = NSObject.alloc().init()
             properties.object = obj

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1068,6 +1068,12 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(r.size.width, 56)
         self.assertEqual(r.size.height, 78)
 
+    def test_class_nonobject_properties_weak(self):
+
+        with self.assertRaises(TypeError):
+            class WeakNonObjectProperties(NSObject):
+                int = objc_property(c_int, weak=True)
+
     def test_class_properties_lifecycle_strong(self):
 
         class StrongProperties(NSObject):


### PR DESCRIPTION
This PR enforces that the vartype of weak properties must be map to `objc_id` or `py_object`, i.e., that the property has an object type. This is because creating and storing weak reference in Objective-C is only supported for object types.

If a weak property is declared with a primitive C type or anything that maps to a primitive ctype, setting the value will succeed without an error but retrieving the value will return something entirely different.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
