### PR TITLE
`send_super` fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: "3.X"
     - name: Install dependencies
@@ -39,7 +39,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.5
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.5
     - name: Install dependencies
@@ -58,7 +58,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
     - name: Install dependencies
@@ -81,7 +81,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/changes/220.bugfix.rst
+++ b/changes/220.bugfix.rst
@@ -1,0 +1,1 @@
+Enforce usage of `argtypes` when calling `send_super`.

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -818,7 +818,8 @@ def send_super(cls, receiver, selector, *args, restype=c_void_p, argtypes=None, 
         pass
 
     # Convert str / bytes to selector
-    selector = SEL(selector)
+    if not isinstance(selector, SEL):
+        selector = SEL(selector)
 
     if argtypes is None:
         argtypes = []

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -683,7 +683,7 @@ def _msg_send_for_types(restype, argtypes):
         return send
 
 
-def send_message(receiver, selector, *args, restype, argtypes, varargs=None):
+def send_message(receiver, selector, *args, restype, argtypes=None, varargs=None):
     """Call a method on the receiver with the given selector and arguments.
 
     This is the equivalent of an Objective-C method call like ``[receiver sel:args]``.
@@ -719,7 +719,7 @@ def send_message(receiver, selector, *args, restype, argtypes, varargs=None):
     :param selector: The name of the method as a :class:`str`, :class:`bytes`, or :class:`SEL`.
     :param args: The method arguments.
     :param restype: The return type of the method.
-    :param argtypes: The argument types of the method, as a :class:`list`.
+    :param argtypes: The argument types of the method, as a :class:`list`. Defaults to ``[]``.
     :param varargs: Variadic arguments for the method, as a :class:`list`. Defaults to ``[]``.
         These arguments are converted according to the default :mod:`ctypes` conversion rules.
     """
@@ -738,14 +738,17 @@ def send_message(receiver, selector, *args, restype, argtypes, varargs=None):
     if not isinstance(selector, SEL):
         selector = SEL(selector)
 
+    if argtypes is None:
+        argtypes = []
+
+    if varargs is None:
+        varargs = []
+
     if len(args) != len(argtypes):
         raise TypeError(
             "Inconsistent number of arguments ({}) and argument types ({})"
             .format(len(args), len(argtypes))
         )
-
-    if varargs is None:
-        varargs = []
 
     send = _msg_send_for_types(restype, argtypes)
 

--- a/tests/objc/BaseExample.h
+++ b/tests/objc/BaseExample.h
@@ -21,6 +21,7 @@
 -(void) mutateBaseIntFieldWithValue: (int) v;
 
 -(void) method:(int) v withArg: (int) m;
+-(void) methodWithArgs: (int) m, ...;
 -(void) method:(int) v;
 
 @end

--- a/tests/objc/BaseExample.m
+++ b/tests/objc/BaseExample.m
@@ -71,6 +71,23 @@ static int _staticBaseIntField = 1;
     self.baseIntField = v * m;
 }
 
+-(void) methodWithArgs: (int) num, ... {
+
+   int sum = 0;
+
+   va_list args;
+   va_start( args, num );
+
+   for( int i = 0; i < num; i++)
+   {
+      sum += va_arg( args, int);
+   }
+
+   va_end( args );
+
+   self.baseIntField = sum;
+}
+
 -(void) method:(int) v{
     self.baseIntField = v;
 }

--- a/tests/objc/SpecificExample.m
+++ b/tests/objc/SpecificExample.m
@@ -7,4 +7,21 @@
     self.baseIntField = v + m;
 }
 
+-(void) methodWithArgs: (int) num, ... {
+
+   int prod = 1;
+
+   va_list args;
+   va_start( args, num );
+
+   for( int i = 0; i < num; i++)
+   {
+      prod *= va_arg( args, int);
+   }
+
+   va_end( args );
+
+   self.baseIntField = prod;
+}
+
 @end

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -397,6 +397,57 @@ class RubiconTest(unittest.TestCase):
 
         self.assertEqual(send_message(obj, SEL("accessIntField"), restype=c_int, argtypes=[]), 33)
 
+    def test_send_super(self):
+        """An instance method of the super class can be invoked"""
+        SpecificExample = ObjCClass("SpecificExample")
+
+        obj = SpecificExample.alloc().init()
+
+        send_super(SpecificExample, obj, "method:withArg:", 2, 5, restype=None, argtypes=[c_int, c_int])
+
+        self.assertEqual(obj.baseIntField, 10)
+
+    def test_send_super_sel(self):
+        """send_super accepts a SEL object as the selector parameter."""
+        SpecificExample = ObjCClass("SpecificExample")
+
+        obj = SpecificExample.alloc().init()
+
+        send_super(SpecificExample, obj, SEL("method:withArg:"), 2, 5, restype=None, argtypes=[c_int, c_int])
+
+        self.assertEqual(obj.baseIntField, 10)
+
+    def test_send_super_incorrect_argument_count(self):
+        """Attempting to call a method with send_super with an incorrect number of arguments throws an exception."""
+        SpecificExample = ObjCClass("SpecificExample")
+
+        obj = SpecificExample.alloc().init()
+
+        with self.assertRaises(TypeError):
+            send_super(SpecificExample, obj, "method:withArg:", 2, restype=None, argtypes=[])
+
+        with self.assertRaises(TypeError):
+            send_super(SpecificExample, obj, "method:withArg:", restype=None, argtypes=[c_int, c_int])
+
+        with self.assertRaises(TypeError):
+            send_super(
+                SpecificExample,
+                obj,
+                "method:withArg:",
+                2, 5, 6, "extra argument",
+                restype=None,
+                argtypes=[c_int, c_int],
+            )
+
+    def test_send_super_varargs(self):
+        """A variadic method can be called using send_super."""
+        SpecificExample = ObjCClass("SpecificExample")
+
+        obj = SpecificExample.alloc().init()
+        send_super(SpecificExample, obj, "methodWithArgs:", 2, varargs=[5, 6], argtypes=[c_int], restype=None)
+
+        self.assertEqual(obj.accessBaseIntField(), 11)
+
     def test_static_field(self):
         "A static field on a class can be accessed and mutated"
         Example = ObjCClass('Example')


### PR DESCRIPTION
This PR fixes #219.

It also aims to provide a uniform API between `send_message` and `send_super`. For `send_super`, `argtypes` is a keyword argument which defaults to an empty list. This can be convenient if there are no `args` provided to the call in the first place. I've therefore adapted this for `send_message` as well. Alternatively, one might make `argtypes` a mandatory argument for `send_super`. In any case, I would argue that a uniform API would be nice here.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
