### PR TITLE
Update platform declarations for macOS CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
   smoke:
     name: Smoke test (3.5)
     needs: beefore
-    runs-on: macos-10.15
+    runs-on: macOS-11
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.5
@@ -51,10 +51,14 @@ jobs:
       run: |
         tox -e py
 
-  macos-versions:
+  macOS-versions:
     name: macOS compatibility test
     needs: smoke
-    runs-on: macos-11.0
+    strategy:
+      max-parallel: 4
+      matrix:
+        platform: ['macOS-12']
+    runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
@@ -73,7 +77,7 @@ jobs:
   python-versions:
     name: Python compatibility test
     needs: smoke
-    runs-on: macos-10.15
+    runs-on: macOS-latest
     strategy:
       max-parallel: 4
       matrix:

--- a/changes/227.misc.rst
+++ b/changes/227.misc.rst
@@ -1,0 +1,1 @@
+CI has been updated to include macOS-12 and remove macOS-10.15.


### PR DESCRIPTION
Github has [announced that they have deprecated the 10.15 runner, and will remove it by 30 Aug 2022](https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/). This moves macOS smoke CI to macOS-11; and adds a matrix for all other CI-supported macOS versions (although there's only macOS-12 at present).

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
