### PR TITLE
Add dependabot config, plus CI config to add changenotes.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates on Sunday, 8PM UTC
+      interval: "weekly"
+      day: "sunday"
+      time: "20:00"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      # Check for updates on Sunday, 8PM UTC
+      interval: "weekly"
+      day: "sunday"
+      time: "20:00"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
     name: Pre-test checks
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 4
       matrix:
         task:
         - 'flake8'
@@ -61,7 +60,6 @@ jobs:
     name: macOS compatibility test
     needs: smoke
     strategy:
-      max-parallel: 4
       matrix:
         platform: ['macOS-12']
     runs-on: ${{ matrix.platform }}
@@ -88,7 +86,6 @@ jobs:
     needs: smoke
     runs-on: macOS-latest
     strategy:
-      max-parallel: 4
       matrix:
         python-version: ["3.5", "3.6", "3.8", "3.9", "3.10", "3.11"]
         # As soon as 3.12.0a1 is released:

--- a/.github/workflows/dependabot-changenote.yml
+++ b/.github/workflows/dependabot-changenote.yml
@@ -1,0 +1,45 @@
+name: Dependabot Change Note
+on:
+  push:
+    branches:
+      - 'dependabot/**'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  changenote:
+    name: Dependabot Change Note
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.actor == 'dependabot[bot]'
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 1
+          token: ${{ secrets.BRUTUS_PAT_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config --local user.email "$(git log --pretty='%ae' -1)"
+          git config --local user.name "Dependabot[bot]"
+
+      - name: Commit Change Note
+        run: |
+          # Fetch PR number for commit from Github API
+          API_URL="${{ github.api_url }}/repos/${{ github.repository }}/commits/${{ github.event.head_commit.id }}/pulls"
+          PR_NUM=$(curl -s -H "Accept: application/vnd.github+json" "${API_URL}" | jq -r '.[].number')
+
+          # Create change note from first line of dependabot commit
+          NEWS=$(printf "${{ github.event.head_commit.message }}" | head -n1 | sed -e 's/Bump/Updated/')
+          printf "${NEWS}.\n" > "./changes/${PR_NUM}.misc.rst"
+
+          # Commit the change note
+          git add "./changes/${PR_NUM}.misc.rst"
+          # "dependabot skip" tells Dependabot to continue rebasing this branch despite foreign commits
+          git commit -m "Add changenote. [dependabot skip]"
+
+      - name: Push
+        run: git push origin

--- a/changes/229.misc.rst
+++ b/changes/229.misc.rst
@@ -1,0 +1,1 @@
+Dependabot has been enabled on the codebase.


### PR DESCRIPTION
Adds a dependabot configuration to check for updates every Sunday, and automatically add a change note to every dependabot update.

Configuration copied from Briefcase; the `BRUTUS_PAT_TOKEN` has been added to the repo config, and the robots user group has been given write access. 

Dependabot has not been enabled, because this CI needs to be in place before dependabot triggers fire.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
