### PR TITLE
Avoid possible double escaping with dependabot commit messages.

### DIFF
--- a/.github/workflows/dependabot-changenote.yml
+++ b/.github/workflows/dependabot-changenote.yml
@@ -33,8 +33,8 @@ jobs:
           PR_NUM=$(curl -s -H "Accept: application/vnd.github+json" "${API_URL}" | jq -r '.[].number')
 
           # Create change note from first line of dependabot commit
-          NEWS=$(printf "${{ github.event.head_commit.message }}" | head -n1 | sed -e 's/Bump/Updated/')
-          printf "${NEWS}.\n" > "./changes/${PR_NUM}.misc.rst"
+          NEWS=$(printf "%s" "${{ github.event.head_commit.message }}" | head -n1 | sed -e 's/Bump/Updated/')
+          printf "%s.\n" "${NEWS}" > "./changes/${PR_NUM}.misc.rst"
 
           # Commit the change note
           git add "./changes/${PR_NUM}.misc.rst"

--- a/changes/234.misc.rst
+++ b/changes/234.misc.rst
@@ -1,0 +1,1 @@
+The Dependabot changelog CI script was modified to avoid potential double escaping.


### PR DESCRIPTION
Following on from [this suggestion](https://github.com/beeware/rubicon-objc/pull/229#discussion_r1019495762), modifies the dependabot changelog script to avoid potential double escaping. 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
