### PR TITLE
Corrected the identification of x86_64 hardware on iOS simulators.

### DIFF
--- a/changes/235.bugfix.rst
+++ b/changes/235.bugfix.rst
@@ -1,0 +1,1 @@
+The check identifying the architecture on which Rubicon is running has been corrected for x86_64 simulators using a recent Python-Apple-support releases.

--- a/rubicon/objc/types.py
+++ b/rubicon/objc/types.py
@@ -1,5 +1,5 @@
 import collections.abc
-import platform
+import os
 import struct
 from ctypes import (
     POINTER,
@@ -90,16 +90,15 @@ __all__ = [
 
 __LP64__ = 8 * struct.calcsize("P") == 64
 
-# platform.machine() indicates the machine's physical architecture,
-# which means that on a 64-bit Intel machine it is always "x86_64",
-# even if Python is built as 32-bit.
-_any_x86 = platform.machine() in ("i386", "x86_64")
+# os.uname() provides system identification details; the `machine` attribute
+# indicates the machine's physical architecture. On a 64-bit Intel machine it is
+# always "x86_64", even if Python is built as 32-bit.
+_machine = os.uname().machine
+_any_x86 = _machine in ("i386", "x86_64")
 __i386__ = _any_x86 and not __LP64__
 __x86_64__ = _any_x86 and __LP64__
 
-# On iOS, platform.machine() is a device identifier like "iPhone9,4",
-# but the platform.version() string contains the architecture.
-_any_arm = "ARM" in platform.version()
+_any_arm = _machine.startswith("arm")
 __arm64__ = _any_arm and __LP64__
 __arm__ = _any_arm and not __LP64__
 

--- a/rubicon/objc/types.py
+++ b/rubicon/objc/types.py
@@ -1,5 +1,5 @@
 import collections.abc
-import os
+import platform
 import struct
 from ctypes import (
     POINTER,
@@ -90,15 +90,18 @@ __all__ = [
 
 __LP64__ = 8 * struct.calcsize("P") == 64
 
-# os.uname() provides system identification details; the `machine` attribute
-# indicates the machine's physical architecture. On a 64-bit Intel machine it is
-# always "x86_64", even if Python is built as 32-bit.
-_machine = os.uname().machine
-_any_x86 = _machine in ("i386", "x86_64")
+# platform.processor() describes the CPU on which the code is running.
+#   * On a 64-bit Intel machine it is always "x86_64", even if Python is built as 32-bit.
+#   * M1 MacBooks return "arm"
+#   * iPhones (as of the late 2022 support packages) return "arm64"
+# This *wont'* work on older iOS support builds, as it relies on the customized
+# platform values added in https://github.com/beeware/Python-Apple-support/commit/2f42105838ab8f6f7e703ddb929d97758a36145e
+_processor = platform.processor()
+_any_x86 = _processor in ("i386", "x86_64")
 __i386__ = _any_x86 and not __LP64__
 __x86_64__ = _any_x86 and __LP64__
 
-_any_arm = _machine.startswith("arm")
+_any_arm = _processor.startswith("arm")
 __arm64__ = _any_arm and __LP64__
 __arm__ = _any_arm and not __LP64__
 

--- a/rubicon/objc/types.py
+++ b/rubicon/objc/types.py
@@ -101,7 +101,14 @@ _any_x86 = _processor in ("i386", "x86_64")
 __i386__ = _any_x86 and not __LP64__
 __x86_64__ = _any_x86 and __LP64__
 
-_any_arm = _processor.startswith("arm")
+if _processor:
+    _any_arm = _processor.startswith("arm")
+else:
+    # Fallback when running on iOS without the support package,
+    # where platform.processor() is an empty string
+    # and the "model" field of uname/platform doesn't indicate the processor architecture.
+    # In that case, look for the architecture in the kernel version string.
+    _any_arm = "ARM" in platform.version()
 __arm64__ = _any_arm and __LP64__
 __arm__ = _any_arm and not __LP64__
 


### PR DESCRIPTION
The Python support packages for 3.11-b1, 3.10-b5, 3.9-8, and 3.8-b10 included changes to `platform.machine()` to provide a way to identify when Python code was running on iOS simulators.

However, Rubicon was using platform.machine() to identify when the simulator was using x86_64 hardware.

As a result, the `__x86_64__` symbol was never set, which altered the way some messages were marshalled. In particular, calls that returned `NSRect` structures would *not* use `obc_msgSend_stret`, causing a segfault when the return value was received.

This PR alters the check to use `os.uname()` instead of `platform`. `os.uname` is a direct operating system call with much more predictable results; platform is interpreted and transformed in a lot of situations.

This also allows us to use the same check for both ARM and x86.

There are existing tests for this behavior; however, the problem only manifests on iOS hardware.

Fixes #235.
Fixes beeware/toga#1696.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
