### PR TITLE
Ensure that `run_forever_cooperatively` starts a full event loop.

### DIFF
--- a/changes/228.bugfix.rst
+++ b/changes/228.bugfix.rst
@@ -1,0 +1,1 @@
+Background threads will no longer lock up on iOS when an asyncio event loop is in use.


### PR DESCRIPTION
Queues a recursive call to `libcf.CFRunLoopRun()` as part of the setup for `run_forever_cooperatively`.

The existing implementation of `run_forever_cooperatively` set up the lifecycle (which was a no-op on iOS), expecting the UIApplicationMain to then start the event loop. It does; however, the event loop that is started in that way appears to have a restricted set of modes; as a result, threads created from the thread that start the event loop get starved because they are only scheduled to run when the main event loop has work to do. This is why "mashing a button" will unstick a child thread; as will queuing a callback that does nothing, but is invoked periodically.

However, `libcf.CFRunLoopRun()` can be invoked recursively; if, when we start the asyncio event loop in "coop" mode, we enqueue a recursive `libcf.CFRunLoopRun()` call, that call will be invoked as soon as the UIApplicationMain starts; but the "inner" event loop is not mode-restricted, and as a result, subthreads aren't starved.

This exposed an edge case with socket callbacks: During shutdown, the reader and write object is set to None, but it is possible for stale socket callback events to be triggered (manifesting as an inability to unpack a `None` object into a (callback, args) tuple. A fix for this is also included.

Fixes #228.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
