### PR TITLE
Mark the tests that fail on M1 hardware as expected failures

### DIFF
--- a/changes/225.misc.rst
+++ b/changes/225.misc.rst
@@ -1,0 +1,1 @@
+Marked some M1 block tests as known failures.

--- a/src/rubicon/objc/api.py
+++ b/src/rubicon/objc/api.py
@@ -2076,7 +2076,7 @@ class ObjCBlock:
         if self.has_helpers:
             representation += ",has_helpers"
         if self.has_signature:
-            representation += ",has_signature:" + self.signature
+            representation += ",has_signature:" + self.signature.decode("utf-8")
         representation += ">"
         return representation
 
@@ -2087,7 +2087,6 @@ class ObjCBlock:
         objects according to the default ``ctypes`` rules, based on the
         block's return and parameter types.
         """
-
         return self.struct.contents.invoke(self.pointer, *args)
 
 

--- a/tests/objc/Blocks.h
+++ b/tests/objc/Blocks.h
@@ -32,7 +32,7 @@ typedef struct
 
 
 @interface BlockReceiverExample : NSObject
-- (void)receiverMethod:(void (^)(int, int))blockArgument;
+- (int)receiverMethod:(int (^)(int, int))blockArgument;
 @end
 
 

--- a/tests/objc/Blocks.m
+++ b/tests/objc/Blocks.m
@@ -53,9 +53,9 @@
 
 @implementation BlockReceiverExample
 
--(void) receiverMethod:(void (^)(int, int))blockArgument
+-(int) receiverMethod:(int (^)(int, int))blockArgument
 {
-    blockArgument(13, 14);
+    return blockArgument(13, 14);
 }
 
 @end

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -79,12 +79,14 @@ class BlockTests(unittest.TestCase):
 
         values = []
 
-        def block(a: int, b: int) -> None:
+        def block(a: int, b: int) -> int:
             values.append(a + b)
+            return 42
 
-        instance.receiverMethod_(block)
+        result = instance.receiverMethod_(block)
 
         self.assertEqual(values, [27])
+        self.assertEqual(result, 42)
 
     def test_block_receiver_unannotated(self):
         BlockReceiverExample = ObjCClass("BlockReceiverExample")

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -1,3 +1,4 @@
+import platform
 import unittest
 from ctypes import Structure, c_int, c_void_p
 
@@ -6,19 +7,29 @@ from rubicon.objc.api import Block
 from rubicon.objc.runtime import objc_block
 
 
+def m1_block_failure(test):
+    if platform.processor().startswith("arm"):
+        return unittest.expectedFailure(test)
+    else:
+        return test
+
+
 class BlockTests(unittest.TestCase):
+    @m1_block_failure
     def test_block_property_ctypes(self):
         BlockPropertyExample = ObjCClass("BlockPropertyExample")
         instance = BlockPropertyExample.alloc().init()
         result = ObjCBlock(instance.blockProperty, c_int, c_int, c_int)(1, 2)
         self.assertEqual(result, 3)
 
+    @m1_block_failure
     def test_block_property_pytypes(self):
         BlockPropertyExample = ObjCClass("BlockPropertyExample")
         instance = BlockPropertyExample.alloc().init()
         result = ObjCBlock(instance.blockProperty, int, int, int)(1, 2)
         self.assertEqual(result, 3)
 
+    @m1_block_failure
     def test_block_delegate_method_manual_ctypes(self):
         class DelegateManualC(NSObject):
             @objc_method
@@ -31,6 +42,7 @@ class BlockTests(unittest.TestCase):
         result = instance.blockExample()
         self.assertEqual(result, 5)
 
+    @m1_block_failure
     def test_block_delegate_method_manual_pytypes(self):
         class DelegateManualPY(NSObject):
             @objc_method
@@ -43,6 +55,7 @@ class BlockTests(unittest.TestCase):
         result = instance.blockExample()
         self.assertEqual(result, 5)
 
+    @m1_block_failure
     def test_block_delegate_auto(self):
         class DelegateAuto(NSObject):
             @objc_method
@@ -55,6 +68,7 @@ class BlockTests(unittest.TestCase):
         result = instance.blockExample()
         self.assertEqual(result, 9)
 
+    @m1_block_failure
     def test_block_delegate_auto_struct(self):
         class BlockStruct(Structure):
             _fields_ = [
@@ -115,6 +129,7 @@ class BlockTests(unittest.TestCase):
 
         self.assertEqual(values, [27])
 
+    @m1_block_failure
     def test_block_round_trip(self):
         BlockRoundTrip = ObjCClass("BlockRoundTrip")
         instance = BlockRoundTrip.alloc().init()
@@ -143,6 +158,7 @@ class BlockTests(unittest.TestCase):
         returned_block_2 = instance.roundTripNoArgs(block_2)
         self.assertEqual(returned_block_2(), 42)
 
+    @m1_block_failure
     def test_block_bound_method(self):
         """A bound method with type annotations can be wrapped in a block."""
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ skip_missing_interpreters = true
 deps =
     pytest
     pytest-tldr
-whitelist_externals =
+allowlist_externals =
     make
 commands =
     make -C tests/objc


### PR DESCRIPTION
Some Block tests currently fail on M1 hardware due to a marshalling problem with blocks. When adding features that aren't related to blocks, these failures mask any new problems; so I've marked them as expected failures for now.

Refs #225 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
