### PR TITLE
Address thread safety issues.

### DIFF
--- a/changes/249.bugfix.rst
+++ b/changes/249.bugfix.rst
@@ -1,0 +1,1 @@
+The ObjCInstance cache no longer returns a stale wrapper objects if a memory address is re-used by the Objective C runtime.

--- a/changes/250.bugfix.rst
+++ b/changes/250.bugfix.rst
@@ -1,0 +1,1 @@
+It is safe to open an asyncio event loop on a secondary thread. Previously this would work, but would intermittently fail with a segfault when then loop was closed.

--- a/changes/251.bugfix.rst
+++ b/changes/251.bugfix.rst
@@ -1,0 +1,1 @@
+A potential race condition that would lead to duplicated creation on ObjCInstance wrapper objects has been resolved.

--- a/changes/252.bugfix.rst
+++ b/changes/252.bugfix.rst
@@ -1,0 +1,1 @@
+A race condition associated with populating the ObjCClass method/property cache has been resolved.

--- a/src/rubicon/objc/api.py
+++ b/src/rubicon/objc/api.py
@@ -1586,7 +1586,7 @@ class ObjCClass(ObjCInstance, type):
 
     def _load_methods(self):
         if self.methods_ptr is not None:
-            raise RuntimeError(f"{self}_load_methods cannot be called more than once")
+            raise RuntimeError(f"{self}._load_methods cannot be called more than once")
 
         methods_ptr_count = c_uint(0)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -11,7 +11,6 @@ from ctypes import (
     c_double,
     c_float,
     c_int,
-    c_uint,
     c_void_p,
     cast,
     create_string_buffer,
@@ -1776,7 +1775,6 @@ class RubiconTest(unittest.TestCase):
             # Manually clear the method/property cache on Example.
             # This returns the attributes set in ObjCClass.__new__
             # to their initial values.
-            Example.methods_ptr_count = c_uint(0)
             Example.methods_ptr = None
             Example.instance_method_ptrs = {}
             Example.instance_methods = {}
@@ -1809,7 +1807,6 @@ class RubiconTest(unittest.TestCase):
             # Manually clear the method/property cache on Example.
             # This returns the attributes set in ObjCClass.__new__
             # to their initial values.
-            Example.methods_ptr_count = c_uint(0)
             Example.methods_ptr = None
             Example.instance_method_ptrs = {}
             Example.instance_methods = {}
@@ -1842,7 +1839,6 @@ class RubiconTest(unittest.TestCase):
             # Manually clear the method/property cache on Example.
             # This returns the attributes set in ObjCClass.__new__
             # to their initial values.
-            Example.methods_ptr_count = c_uint(0)
             Example.methods_ptr = None
             Example.instance_method_ptrs = {}
             Example.instance_methods = {}


### PR DESCRIPTION
This PR addresses a number of thread safety issues with Rubicon, identified as a result of the Toga GUI testbed app.

1. CFEventLoop was always binding to the main thread's event loop. Event loops are thread specific; in some cases, this could lead to a segfault on shutdown, as the cleanup process would attempt to register and close the self-socket, but either the main event loop had been closed and disposed of, or the self-socket was no longer valid. (#250)

2. The call to get a run loop is declared as following the GET convention; without explicit retention, it is possible for the event loop to be disposed of before CFEventLoop has finished with it. This is unlikely to occur in practice, but can't hurt to protect against.

3. Calls to CFEventLoop.stop() weren't invoking logic on the parent; as a result, the `_stopping` flag wouldn't be set.

4. If a socket was disabled and the event loop was in the process of closing and an event occurred, it was possible for a run loop to be removed twice. 

5. If a memory address was used by the Objective C runtime, wrapped in a ObjCInstance object, then disposed of by Objective C, there is a window between that disposal and the removal of the object from the ObjCInstance instance cache. As a result, if the memory address is re-used, a stale wrapper would be returned. That wrapper could (and usually would) have a different type to the new object using the address, causing errors because the "new" object will report as being of a different type, and respond to different methods. (#249)

6. In a multithreaded setup, when creating a new ObjCInstance, it was possible to create 2 different ObjCInstance wrappers for the same memory address; one of those wrappers would be lost from the instance cache (as the ObjC memory address is used as a key). (#251)

7. In a multithreaded setup, it was possible for the method cache to become corrupted if two separate threads attempt to access a method or property on an object at the same time. One of the attempts would discover an empty cache, and attempt to populate that cache; the second attempt would see an apparently populated cache, and look up a method or property. If the first thread had not yet populated the cache for the requested method/attribute, it would report an AttributeError, even though the attribute *should* exist. (#252).

There are tests for 5-7; however, I can't work out how to write tests that will reliably exercise 1-4 to occur.

Fixes #249 
Fixes #250 
Fixes #251
Fixes #252 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
