### PR TITLE
Update references to master in CI badges.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,10 +18,10 @@ Rubicon-ObjC
    :alt: Project status
 
 .. image:: https://img.shields.io/pypi/l/rubicon-objc.svg
-   :target: https://github.com/beeware/rubicon-objc/blob/master/LICENSE
+   :target: https://github.com/beeware/rubicon-objc/blob/main/LICENSE
    :alt: License
 
-.. image:: https://github.com/beeware/rubicon-objc/workflows/CI/badge.svg?branch=master
+.. image:: https://github.com/beeware/rubicon-objc/workflows/CI/badge.svg?branch=main
    :target: https://github.com/beeware/rubicon-objc/actions
    :alt: Build Status
 

--- a/changes/248.misc.rst
+++ b/changes/248.misc.rst
@@ -1,0 +1,1 @@
+Stale references to the master branch in README badges were corrected.


### PR DESCRIPTION
An oversight of the master->main conversion - the CI badges in the README still referred to the master branch.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
