### PR TITLE
Modify CI workflow so that wheels built for test are used for release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,16 @@ jobs:
       - name: Lint with Pre-commit
         uses: pre-commit/action@v3.0.0
 
-  beefore:
-    name: Pre-test checks
+  towncrier:
     runs-on: macos-latest
-    strategy:
-      matrix:
-        task:
-        - "towncrier-check"
-        - "package"
     steps:
-    - name: Check out code
+    # Fetch main branch for comparison, then check out current branch.
+    - name: Check out main branch
+      uses: actions/checkout@v3.3.0
+      with:
+        fetch-depth: 0
+        ref: main
+    - name: Check out branch
       uses: actions/checkout@v3.3.0
       with:
         fetch-depth: 0
@@ -36,18 +36,41 @@ jobs:
       uses: actions/setup-python@v4.5.0
       with:
         python-version: "3.X"
-    - name: Install dependencies
+    - name: Install dev dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade setuptools
-        python -m pip install tox
+        # We don't actually want to install rubicon;
+        # we just want the dev etras so we have a known version of tox
+        python -m pip install -e .[dev]
     - name: Run pre-test check
       run: |
-        tox -e ${{ matrix.task }}
+        tox -e towncrier-check
+
+  package:
+    runs-on: macos-latest
+    steps:
+    # Fetch all refs so setuptools_scm can generate the correct version number.
+    - uses: actions/checkout@v3.3.0
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-python@v4.5.0
+      with:
+        python-version: "3.X"
+    - name: Install dev dependencies
+      run: |
+        # We don't actually want to install rubicon;
+        # we just want the dev extras so we have a known version of tox
+        python -m pip install -e .[dev]
+    - name: Build wheels
+      run: tox -e package
+    - uses: actions/upload-artifact@v3
+      with:
+        name: packages
+        path: dist
+        if-no-files-found: error
 
   unit-tests:
     name: Unit tests
-    needs: [pre-commit, beefore]
+    needs: [pre-commit, towncrier, package]
     strategy:
       matrix:
         platform: ["macOS-11", "macOS-12"]
@@ -67,11 +90,16 @@ jobs:
       uses: actions/setup-python@v4.5.0
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Get packages
+      uses: actions/download-artifact@v3
+      with:
+        name: packages
+        path: dist
+    - name: Install dev dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade setuptools
-        python -m pip install tox
+        # We don't actually want to install rubicon;
+        # we just want the dev extras so we have a known version of tox.
+        python -m pip install $(ls dist/rubicon_objc-*.whl)[dev]
     - name: Test
       run: |
-        tox -e py
+        tox -e py --installpkg dist/rubicon_objc-*.whl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         platform: ["macOS-11", "macOS-12"]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
         include:
           - experimental: false
           - python-version: "3.12-dev"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_call:
 
 jobs:
   pre-commit:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,24 +6,15 @@ on:
 
 jobs:
   deploy:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.3.0
-    - name: Set up Python
-      uses: actions/setup-python@v4.5.0
-      with:
-        python-version: "3.x"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade setuptools
-        python -m pip install tox
-    - name: Build release artefacts
-      run: |
-        tox -e package
-    - name: Publish release
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        tox -e publish
+      - uses: dsaltares/fetch-gh-release-asset@1.1.0
+        with:
+          version: tags/${{ github.event.release.tag_name }}
+          file: ${{ github.event.repository.name }}.*
+          regex: true
+          target: dist/
+      - name: Publish release to production PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,19 +6,44 @@ on:
       - "v*"
 
 jobs:
-  build:
+  ci:
+    uses: ./.github/workflows/ci.yml
+  release:
     name: Create Release
-    runs-on: macos-latest
+    needs: ci
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3.3.0
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set build variables
+        run: |
+          echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+      - name: Set up Python
+        uses: actions/setup-python@v4.5.0
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          python-version: '3.x'
+      - name: Get packages
+        uses: actions/download-artifact@v3
+        with:
+          name: packages
+          path: dist
+      - name: Install packages
+        run: pip install dist/rubicon_objc-*.whl
+      - name: Check version number
+        # Check that the setuptools_scm-generated version number is still the same when
+        # installed from a wheel with setuptools_scm not present.
+        run: |
+          set -x
+          test $(python -c "from rubicon.objc import __version__; print(__version__)") = $VERSION
+      - name: Create Release
+        uses: ncipollo/release-action@v1.12.0
+        with:
+          name: ${{ env.VERSION }}
           draft: true
-          prerelease: false
+          artifacts: dist/*
+          artifactErrorsFailBuild: true
+      - name: Publish release to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository_url: https://test.pypi.org/legacy/
+          password: ${{ secrets.TEST_PYPI_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   release:
     name: Create Release
     needs: ci
-    runs-on: ubuntu-latest
+    runs-on: macOS-latest
     permissions:
       contents: write
     steps:
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4.5.0
         with:
-          python-version: '3.x'
+          python-version: '3.X'
       - name: Get packages
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,11 @@ on:
 jobs:
   ci:
     uses: ./.github/workflows/ci.yml
+
   release:
     name: Create Release
-    needs: ci
+    needs: [ci]
+    # This has to be run on macOS, because rubicon tries to load the Foundation library
     runs-on: macOS-latest
     permissions:
       contents: write
@@ -42,6 +44,19 @@ jobs:
           draft: true
           artifacts: dist/*
           artifactErrorsFailBuild: true
+
+  test-publish:
+    name: Publish test package
+    needs: [release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Get packages
+        uses: actions/download-artifact@v3
+        with:
+          name: packages
+          path: dist
       - name: Publish release to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/changes/254.misc.rst
+++ b/changes/254.misc.rst
@@ -1,0 +1,1 @@
+The CI configuration was modified to publish the same artefacts used for testing, with a version number coming from git.

--- a/changes/371.feature.rst
+++ b/changes/371.feature.rst
@@ -1,0 +1,1 @@
+Support for Python 3.6 was dropped.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,8 +10,8 @@
 # serve to show the default.
 
 import os
-import re
 import sys
+from importlib.metadata import version as metadata_version
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -48,17 +48,7 @@ copyright = "2014, Russell Keith-Magee"
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-with open("../src/rubicon/objc/__init__.py", encoding="utf8") as version_file:
-    version_match = re.search(
-        r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.MULTILINE
-    )
-    if version_match:
-        release = version_match.group(1)
-    else:
-        raise RuntimeError("Unable to find version string.")
-
-# The short X.Y version.
-version = ".".join(release.split(".")[:2])
+version = metadata_version("rubicon-objc")
 
 autoclass_content = "both"
 

--- a/docs/how-to/internal/release.rst
+++ b/docs/how-to/internal/release.rst
@@ -21,46 +21,63 @@ The procedure for cutting a new release is as follows:
 
    Check that the HEAD of release now matches upstream/main.
 
-2. Make sure the branch is ready for release. Ensure that:
+2. Ensure that the release notes are up to date. Run::
 
-   1. The version number has been bumped.
-
-   2. The release notes are up to date. If they are, the `changes
-      <https://github.com/beeware/rubicon-objc/tree/main/changes>`__ directory
-      should be empty, except for the ``template.rst`` file.
-
-   These two changes (the version bump and release notes update) should go
-   through the normal pull request and review process. They should generally
-   comprise the last PR merged before the release occurs.
-
-   If the version number *hasn't* been updated, or ``changes`` directory
-   *isn't* empty, you need to create a PR (using the normal development
-   process) that contains these changes. Run::
-
-         $ tox -e towncrier -- --draft
+      $ tox -e towncrier -- --draft
 
    to review the release notes that will be included, and then::
 
          $ tox -e towncrier
 
-   to generate the updated release notes. Submit the PR; once it's been
-   reviewed and merged, you can restart the release process from step 1.
+   to generate the updated release notes.
 
 3. Tag the release, and push the tag upstream::
 
     $ git tag v1.2.3
+    $ git push upstream HEAD:main
     $ git push upstream v1.2.3
 
 4. Pushing the tag will start a workflow to create a draft release on GitHub.
    You can `follow the progress of the workflow on GitHub
    <https://github.com/beeware/rubicon-objc/actions?query=workflow%3A%22Create+Release%22>`__;
    once the workflow completes, there should be a new `draft release
-   <https://github.com/beeware/rubicon-objc/releases>`__.
+   <https://github.com/beeware/rubicon-objc/releases>`__, and an entry on the
+   `Test PyPI server <https://test.pypi.org/project/rubicon-objc/>`__.
 
-5. Edit the GitHub release. Add release notes (you can use the text generated
+   Confirm that this action successfully completes. If it fails, there's a
+   couple of possible causes:
+
+   a. The final upload to Test PyPI failed. Test PyPI is not have the same
+      service monitoring as PyPI-proper, so it sometimes has problems. However,
+      it's also not critical to the release process; if this step fails, you can
+      perform Step 6 by manually downloading the "packages" artifact from the
+      GitHub workflow instead.
+   b. Something else fails in the build process. If the problem can be fixed
+      without a code change to the Rubicon-ObjC repository (e.g., a transient
+      problem with build machines not being available), you can re-run the
+      action that failed through the Github Actions GUI. If the fix requires a
+      code change, delete the old tag, make the code change, and re-tag the
+      release.
+
+5. Create a clean virtual environment, install the new release from Test PyPI, and
+   perform any pre-release testing that may be appropriate::
+
+    $ python3 -m venv testvenv
+    $ . ./testvenv/bin/activate
+    (testvenv) $ pip install --extra-index-url https://test.pypi.org/simple/ rubicon-objc==1.2.3
+    (testvenv) $ python -c "from rubicon.objc import __version__; print(__version__)"
+    1.2.3
+    (testvenv) $ ... any other manual checks you want to perform ...
+
+6. Log into ReadTheDocs, visit the `Versions tab
+   <https://readthedocs.org/projects/rubicon-objc/versions/>`__, and activate the
+   new version. Ensure that the build completes; if there's a problem, you
+   may need to correct the build configuration, roll back and re-tag the release.
+
+7. Edit the GitHub release. Add release notes (you can use the text generated
    by towncrier). Check the pre-release checkbox (if necessary).
 
-6. Double check everything, then click Publish. This will trigger a
+8. Double check everything, then click Publish. This will trigger a
    `publication workflow on GitHub
    <https://github.com/beeware/rubicon-objc/actions?query=workflow%3A%22Upload+Python+Package%22>`__.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [build-system]
-requires = [
-    "setuptools >= 46.4.0",
-    "wheel >= 0.32.0",
-]
+requires = ["setuptools>=60", "setuptools_scm[toml]>=7.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.isort]
 profile = "black"
 split_on_trailing_comma = true
 combine_as_imports = true
+
+[tool.setuptools_scm]
+# To enable SCM versioning, we need an empty tool configuration for setuptools_scm
 
 [tool.towncrier]
 directory = "changes"

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     License :: OSI Approved :: BSD License
     Programming Language :: Objective C
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -31,7 +30,7 @@ long_description = file: README.rst
 long_description_content_type = text/x-rst
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 packages = find:
 package_dir =
     = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,9 @@ python_requires = >=3.6
 packages = find:
 package_dir =
     = src
+install_requires =
+    # We need importlib.metadata.version, added in Python 3.8
+    importlib_metadata >= 4.4; python_version < "3.8"
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = rubicon-objc
-version = attr: rubicon.objc.__version__
 url = https://beeware.org/rubicon
 project_urls =
     Funding = https://beeware.org/contributing/membership/
@@ -43,6 +42,9 @@ where = src
 [options.extras_require]
 dev =
     pre-commit == 2.21.0
+    pytest == 7.2.1
+    pytest-tldr == 0.2.5
+    setuptools_scm[toml] == 7.1.0
     tox == 4.3.5
 docs =
     furo == 2022.12.7

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()

--- a/src/rubicon/objc/__init__.py
+++ b/src/rubicon/objc/__init__.py
@@ -11,7 +11,12 @@ except (ModuleNotFoundError, LookupError):
     # If it *is* in the environment, but the code isn't a git checkout (e.g.,
     # it's been pip installed non-editable) the call to get_version() will fail.
     # If either of these occurs, read version from the installer metadata.
-    from importlib.metadata import version
+
+    # importlib.metadata.versoin was added in Python 3.8
+    try:
+        from importlib.metadata import version
+    except ModuleNotFoundError:
+        from importlib_metadata import version
 
     __version__ = version("rubicon-objc")
 

--- a/src/rubicon/objc/__init__.py
+++ b/src/rubicon/objc/__init__.py
@@ -1,12 +1,19 @@
-# Examples of valid version strings
-# __version__ = '1.2.3.dev1'  # Development release 1
-# __version__ = '1.2.3a1'     # Alpha Release 1
-# __version__ = '1.2.3b1'     # Beta Release 1
-# __version__ = '1.2.3rc1'    # RC Release 1
-# __version__ = '1.2.3'       # Final Release
-# __version__ = '1.2.3.post1' # Post Release 1
+try:
+    # Read version from SCM metadata
+    # This will only exist in a development environment
+    from setuptools_scm import get_version
 
-__version__ = "0.4.4"
+    # Excluded from coverage because a pure test environment (such as the one
+    # used by tox in CI) won't have setuptools_scm
+    __version__ = get_version("../../..", relative_to=__file__)  # pragma: no cover
+except (ModuleNotFoundError, LookupError):
+    # If setuptools_scm isn't in the environment, the call to import will fail.
+    # If it *is* in the environment, but the code isn't a git checkout (e.g.,
+    # it's been pip installed non-editable) the call to get_version() will fail.
+    # If either of these occurs, read version from the installer metadata.
+    from importlib.metadata import version
+
+    __version__ = version("rubicon-objc")
 
 # `api`, `runtime` and `types` are only included for clarity. They are not
 # strictly necessary, because the from-imports below also import the types and
@@ -18,11 +25,8 @@ __version__ = "0.4.4"
 # of ObjCInstance when representing Foundation collections in Python. If this
 # module is not imported, the registration will not take place, and Foundation
 # collections will not support the expected methods/operators in Python!
-from . import api  # noqa: F401
-from . import collections  # noqa: F401
-from . import runtime  # noqa: F401
-from . import types  # noqa: F401
-from .api import (  # noqa: F401
+from . import api, collections, runtime, types
+from .api import (
     Block,
     NSArray,
     NSDictionary,
@@ -45,8 +49,8 @@ from .api import (  # noqa: F401
     objc_rawmethod,
     py_from_ns,
 )
-from .runtime import SEL, send_message, send_super  # noqa: F401
-from .types import (  # noqa: F401
+from .runtime import SEL, send_message, send_super
+from .types import (
     CFIndex,
     CFRange,
     CGFloat,
@@ -76,3 +80,63 @@ from .types import (  # noqa: F401
     UniChar,
     unichar,
 )
+
+__all__ = [
+    "__version__",
+    CFIndex,
+    CFRange,
+    CGFloat,
+    CGGlyph,
+    CGPoint,
+    CGPointMake,
+    CGRect,
+    CGRectMake,
+    CGSize,
+    CGSizeMake,
+    NSEdgeInsets,
+    NSEdgeInsetsMake,
+    NSInteger,
+    NSMakePoint,
+    NSMakeRect,
+    NSMakeSize,
+    NSPoint,
+    NSRange,
+    NSRect,
+    NSSize,
+    NSTimeInterval,
+    NSUInteger,
+    NSZeroPoint,
+    UIEdgeInsets,
+    UIEdgeInsetsMake,
+    UIEdgeInsetsZero,
+    UniChar,
+    unichar,
+    SEL,
+    send_message,
+    send_super,
+    Block,
+    NSArray,
+    NSDictionary,
+    NSMutableArray,
+    NSMutableDictionary,
+    NSObject,
+    NSObjectProtocol,
+    ObjCBlock,
+    ObjCClass,
+    ObjCInstance,
+    ObjCMetaClass,
+    ObjCProtocol,
+    at,
+    ns_from_py,
+    objc_classmethod,
+    objc_const,
+    objc_ivar,
+    objc_method,
+    objc_property,
+    objc_rawmethod,
+    py_from_ns,
+    api,
+    collections,
+    runtime,
+    types,
+]

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -187,6 +187,6 @@ class AsyncSubprocessTests(unittest.TestCase):
         # Everything in the sample set, less everything from the result,
         # should be an empty set.
         self.assertEqual(
-            {"README.rst", "MANIFEST.in", "setup.py", "setup.cfg"} - task.result(),
+            {"README.rst", "MANIFEST.in", "setup.cfg"} - task.result(),
             set(),
         )

--- a/tox.ini
+++ b/tox.ini
@@ -8,22 +8,17 @@ envlist = flake8,towncrier-check,docs,package,py{36,37,38,39,310,311,312},pypy3
 skip_missing_interpreters = true
 
 [testenv]
-deps =
-    pytest
-    pytest-tldr
+extras =
+    dev
 allowlist_externals =
     make
 commands =
     make -C tests/objc
     pytest -vv
 
-[testenv:flake8]
-skip_install = True
-deps =
-    flake8
-commands = flake8 {posargs}
-
 [testenv:towncrier-check]
+package_env = none
+skip_install = True
 deps =
     {[testenv:towncrier]deps}
 commands =
@@ -42,6 +37,8 @@ commands =
     python -m sphinx -W docs build/sphinx
 
 [testenv:package]
+package_env = none
+skip_install = True
 deps =
     check_manifest
     build
@@ -50,13 +47,3 @@ commands =
     check-manifest -v
     python -m build --outdir dist/ .
     python -m twine check dist/*
-
-[testenv:publish]
-deps =
-    wheel
-    twine
-passenv =
-    TWINE_USERNAME
-    TWINE_PASSWORD
-commands =
-    python -m twine upload dist/*


### PR DESCRIPTION
In the previous CI configuration, the wheels released to PyPI were built independently of the testing process.

This PR modifies CI so that wheels are built; testing is performed using those wheels; and if testing passes, those same wheels are uploaded to the Test PyPI server. On publication, the same wheel is pushed to the production PyPI server.

This also includes moving to setuptools_scm to determine the version number of the package, removing the possibility of pushing a version whose release number in code doesn't match the tagged release.

It also drops support for Python 3.6. Python 3.6 has been unsupported for over a year; forcing the issue, setuptools_scm has dropped support for Python 3.6.

The configuration changes have been borrowed extensively from Briefcase's configuration.

As a test - I tagged a v0.4.4.post3 release; I've since deleted the tag, since it's misleading; but [this is the CI run](https://github.com/beeware/rubicon-objc/actions/runs/3984016509), and the [package exists on TestPyPI](https://test.pypi.org/project/rubicon-objc/0.4.4.post3/). This doesn't exercise the "publish" workflow, but that workflow is identical to Briefcase.

Fixes #254

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
