### PR TITLE
Allow for some class renames between alloc and init

### DIFF
--- a/changes/258.bugfix.rst
+++ b/changes/258.bugfix.rst
@@ -1,0 +1,1 @@
+Classes that undergo a class name change between ``alloc()`` and ``init()`` (e.g., ``NSWindow`` becomes ``NSKVONotifying_Window``) no longer trigger instance cache eviction logic.

--- a/tests/objc/Altered_Example.h
+++ b/tests/objc/Altered_Example.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+#import "Example.h"
+
+@interface Altered_Example : Example {
+
+}
+
+@end

--- a/tests/objc/Altered_Example.m
+++ b/tests/objc/Altered_Example.m
@@ -1,0 +1,6 @@
+#import "Altered_Example.h"
+#import <stdio.h>
+
+@implementation Altered_Example
+
+@end

--- a/tests/objc/Example.h
+++ b/tests/objc/Example.h
@@ -63,6 +63,7 @@ extern NSString *const SomeGlobalStringConstant;
 +(void) mutateStaticIntFieldWithValue: (int) v;
 
 -(id) init;
+-(id) initWithClassChange;
 -(id) initWithIntValue: (int) v;
 -(id) initWithBaseIntValue: (int) b intValue: (int) v;
 

--- a/tests/objc/Example.m
+++ b/tests/objc/Example.m
@@ -1,5 +1,7 @@
 #import "Example.h"
+#import "Altered_Example.h"
 #import <stdio.h>
+#import <objc/runtime.h>
 
 NSString *const SomeGlobalStringConstant = @"Some global string constant";
 
@@ -57,6 +59,19 @@ static int _staticIntField = 11;
         [self setIntField:33];
     }
     _ambiguous = 42;
+    return self;
+}
+
+-(id) initWithClassChange
+{
+    self = [super initWithIntValue:44];
+
+    if (self) {
+        [self setIntField:55];
+    }
+    _ambiguous = 37;
+
+    object_setClass(self, [Altered_Example class]);
     return self;
 }
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1726,6 +1726,24 @@ class RubiconTest(unittest.TestCase):
             # so the expected method won't exist, causing an AttributeError.
             self.fail("Stale wrapper returned")
 
+    def test_compatible_class_name_change(self):
+        "If the class name changes in a compatible way, the wrapper isn't recreated (#257)"
+        Example = ObjCClass("Example")
+
+        pre_init = Example.alloc()
+
+        # Call initWithClassChange(), which does an internal class name change.
+        # This mirrors what happens with NSWindow, where `init()` changes the
+        # class name to NSKVONotifying_NSWindow.
+        post_init = pre_init.initWithClassChange()
+
+        # Memory address hasn't changed
+        assert pre_init.ptr.value == post_init.ptr.value
+        # The class name hasn't changed either
+        assert pre_init.objc_class.name == post_init.objc_class.name == "Example"
+        # The wrapper is the same object
+        assert id(pre_init) == id(post_init)
+
     def test_threaded_wrapper_creation(self):
         "If 2 threads try to create a wrapper for the same object, only 1 wrapper is created (#251)"
         # Create an ObjC instance, and keep a track of the memory address


### PR DESCRIPTION
Some classes (most notably `NSWindow`, but there are others) undergo a class rename between `alloc()` and `init()` (`NSWindow` becomes `NSKVONotifying_NSWindow`). This PR allows for one specific pattern of class renames to *not* trigger the instance cache eviction due to a class rename.

Fixes #257.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
