### PR TITLE
Add GitHub workflow to keep `pre-commit` hooks up-to-date

### DIFF
--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -1,0 +1,12 @@
+name: Update pre-commit
+
+on:
+  schedule:
+    - cron: "0 20 * * SUN" # Sunday @ 2000 UTC
+  workflow_dispatch:
+
+jobs:
+  pre-commit-update:
+    name: Update pre-commit
+    uses: beeware/.github/.github/workflows/pre-commit-update.yml@main
+    secrets: inherit

--- a/changes/263.misc.rst
+++ b/changes/263.misc.rst
@@ -1,0 +1,1 @@
+A GitHub workflow now runs every Sunday at 2000 UTC to check for updates to ``pre-commit`` hooks and commits them to a new PR.


### PR DESCRIPTION
Implementing here first since Briefcase is using `flake8-eradicate` which isn't ready for `flake8==6.0.0`. Experimenting with this locally, the new version of `black` will make a couple updates.

I left `workflow_dispatch` enabled but I can remove it if we don't want anyone to be able to kick this off manually.

See beeware/.github#6 for details.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
