### PR TITLE
Tweak the publication script to include wheels.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,10 @@ jobs:
       - uses: dsaltares/fetch-gh-release-asset@1.1.0
         with:
           version: tags/${{ github.event.release.tag_name }}
-          file: ${{ github.event.repository.name }}.*
+          # This next line is *not* a bash filename expansion - it's a regex.
+          # We need to match all files that start with rubicon-objc or
+          # rubicon_objc, but not the "Source code" zip and tarball.
+          file: rubicon.*
           regex: true
           target: dist/
       - name: Publish release to production PyPI

--- a/changes/264.misc.rst
+++ b/changes/264.misc.rst
@@ -1,0 +1,1 @@
+The publication workflow was corrected to ensure wheels are published.


### PR DESCRIPTION
[Reported via Discord](https://discord.com/channels/836455665257021440/836455665257021443/1070475568677654529) - the 0.4.5rc1 release had a tarball, but not a wheel.

The wheel was produced, and is attached as an artefact, but the [publication step](https://github.com/beeware/rubicon-objc/actions/runs/4001537281/jobs/6867862149) didn't upload the wheel - only the tarball.

On investigation: this is because the `file` parameter to the `dsaltares/fetch-gh-release-asset` action is a regex, not a filesystem expansion. This isn't explicitly documented, but it possible to reverse engineer from the `"plague-.*\\.zip"` "range of assets" example).

The old `file` pattern used `{{ repository name }}.*`; the repository name is `rubicon-objc`, and `rubicon-objc.*` matches the `rubicon-objc-0.4.5rc1.tar.gz` tarball release asset, but not the `rubicon_objc-0.4.5rc1-py3-none-any.whl` wheel.

I initially thought this would also affect toga; but there, the repository name is `toga`, so `toga.*` matches all assets; there's then a subsequent step that copies *just* the assets for a single sub-project that includes a pattern match that accommodates both `-` and `_`

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
