### PR TITLE
Update pyupgrade to set py3.7 minimum

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     rev: v2.38.2
     hooks:
       - id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]
   # Docformatter is RST-unaware, and may break markup by inserting or removing newlines
   # (see https://github.com/PyCQA/docformatter/issues/124 and linked issues). Until this
   # is fixed, it's not safe to run it automatically.

--- a/changes/266.misc.rst
+++ b/changes/266.misc.rst
@@ -1,0 +1,1 @@
+A backwards compatibility shim for Python 3.6 was removed.

--- a/docs/background/releases.rst
+++ b/docs/background/releases.rst
@@ -9,7 +9,7 @@ Release History
 Features
 --------
 
-* Support for Python 3.6 was dropped. (#371)
+* Support for Python 3.6 was dropped. (#255)
 
 Misc
 ----


### PR DESCRIPTION
#255 dropped support for Python 3.6; but we didn't update pyupgrade at the same time.

This allows us to remove one backwards compatibility shim.

Also fixes the ticket ID associated with the deprecation... ticket 371 doesn't exist yet.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
