### PR TITLE
Improve error message when a selector argument has the wrong type

### DIFF
--- a/changes/271.bugfix.rst
+++ b/changes/271.bugfix.rst
@@ -1,0 +1,1 @@
+The error message returned when a selector has the wrong type has been improved.

--- a/src/rubicon/objc/runtime.py
+++ b/src/rubicon/objc/runtime.py
@@ -835,11 +835,12 @@ def send_message(receiver, selector, *args, restype, argtypes=None, varargs=None
     try:
         result = send(receiver, selector, *args, *varargs)
     except ArgumentError as error:
-        # Re-raise as a TypeError
-        raise TypeError(
-            f"{error.args[0]} ({selector.name.decode()} "
-            f"argtypes: {', '.join(t.__name__ for t in argtypes)})"
-        )
+        # Add more useful info to the default error message, then reraise.
+        err = error.args[0]
+        sel = selector.name.decode(errors="backslashreplace")
+        valid_args = ", ".join(t.__name__ for t in argtypes)
+        error.args = [f"{sel} {err}; argtypes: {valid_args}"]
+        raise error
 
     if restype == c_void_p:
         result = c_void_p(result)

--- a/src/rubicon/objc/runtime.py
+++ b/src/rubicon/objc/runtime.py
@@ -835,9 +835,11 @@ def send_message(receiver, selector, *args, restype, argtypes=None, varargs=None
     try:
         result = send(receiver, selector, *args, *varargs)
     except ArgumentError as error:
-        # Add more useful info to argument error exceptions, then reraise.
-        error.args = f"{error.args[0]} (selector = {selector}, argtypes = {argtypes})"
-        raise
+        # Re-raise as a TypeError
+        raise TypeError(
+            f"{error.args[0]} ({selector.name.decode()} "
+            f"argtypes: {', '.join(t.__name__ for t in argtypes)})"
+        )
 
     if restype == c_void_p:
         result = c_void_p(result)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -381,6 +381,18 @@ class RubiconTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             obj.mutateIntFieldWithValue_(123, "extra argument")
 
+    def test_method_incorrect_argument_type(self):
+        """Attempting to call a method with the wrong type of argument throws an exception."""
+
+        Example = ObjCClass("Example")
+        obj = Example.alloc().init()
+
+        with self.assertRaisesRegex(
+            TypeError,
+            r"argument 3: TypeError: wrong type \(mutateIntFieldWithValue: argtypes: c_int\)",
+        ):
+            obj.mutateIntFieldWithValue_(1.234)
+
     def test_method_incorrect_argument_count_send(self):
         """Attempting to call a method with send_message with an incorrect
         number of arguments throws an exception."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,10 +1,12 @@
 import functools
 import gc
 import math
+import sys
 import threading
 import unittest
 import weakref
 from ctypes import (
+    ArgumentError,
     Structure,
     byref,
     c_char,
@@ -388,10 +390,12 @@ class RubiconTest(unittest.TestCase):
         obj = Example.alloc().init()
 
         with self.assertRaisesRegex(
-            TypeError,
-            # This pattern match needs to be flexible because the exact
-            # text returned in the ctype error changes between Python versions.
-            r"argument 3: .*?: wrong type \(mutateIntFieldWithValue: argtypes: c_int\)",
+            ArgumentError,
+            (
+                r"mutateIntFieldWithValue: argument 3: TypeError: wrong type; argtypes: c_int"
+                if sys.version_info >= (3, 10)
+                else r"mutateIntFieldWithValue: argument 3: <class 'TypeError'>: wrong type; argtypes: c_int"
+            ),
         ):
             obj.mutateIntFieldWithValue_(1.234)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -389,7 +389,9 @@ class RubiconTest(unittest.TestCase):
 
         with self.assertRaisesRegex(
             TypeError,
-            r"argument 3: TypeError: wrong type \(mutateIntFieldWithValue: argtypes: c_int\)",
+            # This pattern match needs to be flexible because the exact
+            # text returned in the ctype error changes between Python versions.
+            r"argument 3: .*?: wrong type \(mutateIntFieldWithValue: argtypes: c_int\)",
         ):
             obj.mutateIntFieldWithValue_(1.234)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -391,10 +391,13 @@ class RubiconTest(unittest.TestCase):
 
         with self.assertRaisesRegex(
             ArgumentError,
-            (
-                r"mutateIntFieldWithValue: argument 3: TypeError: wrong type; argtypes: c_int"
+            r"mutateIntFieldWithValue: argument 3: "
+            + (
+                r"TypeError: 'float' object cannot be interpreted as an integer; argtypes: c_int"
+                if sys.version_info >= (3, 12)
+                else r"TypeError: wrong type; argtypes: c_int"
                 if sys.version_info >= (3, 10)
-                else r"mutateIntFieldWithValue: argument 3: <class 'TypeError'>: wrong type; argtypes: c_int"
+                else r"<class 'TypeError'>: wrong type; argtypes: c_int"
             ),
         ):
             obj.mutateIntFieldWithValue_(1.234)


### PR DESCRIPTION
When a selector is provided an argument of the wrong argument type, the error message is (a) a raw ctypes error, (b) includes lots of Rubicon and Python internal detail (e.g., class reprs), and (c) is rendered incorrectly, because the exception argument is provided as a string, not a list.

This alters the exception so it is a Python TypeError (matching what would be returned by a "normal" Python method; and cleans up the message so it only contains the useful pieces of data.

Fixes #271.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
