### PR TITLE
flake8 tweaks

### DIFF
--- a/changes/285.misc.rst
+++ b/changes/285.misc.rst
@@ -1,0 +1,1 @@
+Removed unnecessary ``noqa`` markers for flake8 and simplified the configuration.

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,5 +64,8 @@ exclude=\
     venv*/*,\
     local/*,\
     .tox/*
-max-complexity = 20
-ignore = E203,E266,E501,W503
+max-line-length = 119
+extend-ignore =
+    # whitespace before :
+    # See https://github.com/PyCQA/pycodestyle/issues/373
+    E203,

--- a/src/rubicon/objc/api.py
+++ b/src/rubicon/objc/api.py
@@ -260,7 +260,8 @@ class ObjCPartialMethod:
             name, order = self.methods[rest]
         except KeyError:
             raise ValueError(
-                f"No method was found starting with {self.name_start!r} and with keywords {set(kwargs)}\nKnown keywords are:\n"
+                f"No method was found starting with {self.name_start!r} and with keywords {set(kwargs)}\n"
+                f"Known keywords are:\n"
                 + "\n".join(repr(keywords) for keywords in self.methods)
             )
 
@@ -1544,7 +1545,7 @@ class ObjCClass(ObjCInstance, type):
             property can be declared explicitly using
             ``NSObject.declare_property('description')``, so that it can always
             be accessed using ``obj.description``.
-        """  # noqa: E501 # The links in the docstring above are too long to wrap to 120 chars.
+        """
 
         self.forced_properties.add(name)
 

--- a/src/rubicon/objc/runtime.py
+++ b/src/rubicon/objc/runtime.py
@@ -224,7 +224,7 @@ class objc_property_t(c_void_p):
 class objc_property_attribute_t(Structure):
     """The `objc_property_attribute_t <https://developer.apple.com/documentation/objectivec/objc_property_attribute_t?language=objc>`__
     structure from ``<objc/runtime.h>``.
-    """
+    """  # noqa: E501
 
     _fields_ = [
         ("name", c_char_p),
@@ -545,7 +545,7 @@ libobjc.property_copyAttributeList.argtypes = [objc_property_t, POINTER(c_uint)]
 class objc_method_description(Structure):
     """The `objc_method_description <https://developer.apple.com/documentation/objectivec/objc_method_description?language=objc>`__
     structure from ``<objc/runtime.h>``.
-    """
+    """  # noqa: E501
 
     _fields_ = [
         ("name", SEL),
@@ -804,7 +804,7 @@ def send_message(receiver, selector, *args, restype, argtypes=None, varargs=None
     :param varargs: Variadic arguments for the method, as a :class:`list`.
         Defaults to ``[]``. These arguments are converted according to the
         default :mod:`ctypes` conversion rules.
-    """
+    """  # noqa: E501
 
     try:
         receiver = receiver._as_parameter_
@@ -813,7 +813,8 @@ def send_message(receiver, selector, *args, restype, argtypes=None, varargs=None
 
     if not isinstance(receiver, objc_id):
         raise TypeError(
-            f"Receiver must be an ObjCInstance or objc_id, not {type(receiver).__module__}.{type(receiver).__qualname__}"
+            f"Receiver must be an ObjCInstance or objc_id, "
+            f"not {type(receiver).__module__}.{type(receiver).__qualname__}"
         )
 
     if not isinstance(selector, SEL):

--- a/src/rubicon/objc/types.py
+++ b/src/rubicon/objc/types.py
@@ -94,8 +94,8 @@ __LP64__ = 8 * struct.calcsize("P") == 64
 #   * On a 64-bit Intel machine it is always "x86_64", even if Python is built as 32-bit.
 #   * M1 MacBooks return "arm"
 #   * iPhones (as of the late 2022 support packages) return "arm64"
-# This *wont'* work on older iOS support builds, as it relies on the customized
-# platform values added in https://github.com/beeware/Python-Apple-support/commit/2f42105838ab8f6f7e703ddb929d97758a36145e
+# This *won't* work on older iOS support builds, as it relies on the customized
+# platform values added in https://github.com/beeware/Python-Apple-support/commit/2f42105838ab8f6f7e703ddb929d97758a36145e  # noqa: E501
 _processor = platform.processor()
 _any_x86 = _processor in ("i386", "x86_64")
 __i386__ = _any_x86 and not __LP64__

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -337,7 +337,7 @@ class RubiconTest(unittest.TestCase):
             issubclass(NSObject.new(), NSSecureCoding)
 
     def test_field(self):
-        "A field on an instance can be accessed and mutated"
+        """A field on an instance can be accessed and mutated"""
 
         Example = ObjCClass("Example")
 
@@ -353,7 +353,7 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(obj.intField, 9999)
 
     def test_method(self):
-        "An instance method can be invoked."
+        """An instance method can be invoked."""
         Example = ObjCClass("Example")
 
         obj = Example.alloc().init()
@@ -446,7 +446,7 @@ class RubiconTest(unittest.TestCase):
         )
 
     def test_method_send(self):
-        "An instance method can be invoked with send_message."
+        """An instance method can be invoked with send_message."""
         Example = ObjCClass("Example")
 
         obj = Example.alloc().init()
@@ -570,7 +570,7 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(obj.accessBaseIntField(), 11)
 
     def test_static_field(self):
-        "A static field on a class can be accessed and mutated"
+        """A static field on a class can be accessed and mutated"""
         Example = ObjCClass("Example")
 
         Example.mutateStaticBaseIntFieldWithValue_(1)
@@ -586,7 +586,7 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(Example.staticIntField, 1199)
 
     def test_static_method(self):
-        "A static method on a class can be invoked."
+        """A static method on a class can be invoked."""
         Example = ObjCClass("Example")
 
         Example.mutateStaticBaseIntFieldWithValue_(2288)
@@ -596,7 +596,7 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(Example.accessStaticIntField(), 2299)
 
     def test_mutator_like_method(self):
-        "A method that looks like a mutator doesn't confuse issues."
+        """A method that looks like a mutator doesn't confuse issues."""
         Example = ObjCClass("Example")
 
         obj1 = Example.alloc().init()
@@ -618,7 +618,7 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(obj1.specialValue, 37)
 
     def test_property_forcing(self):
-        "An instance or property method can be explicitly declared as a property."
+        """An instance or property method can be explicitly declared as a property."""
         Example = ObjCClass("Example")
         Example.declare_class_property("classMethod")
         Example.declare_class_property("classAmbiguous")
@@ -649,7 +649,7 @@ class RubiconTest(unittest.TestCase):
         )
 
     def test_non_existent_field(self):
-        "An attribute error is raised if you invoke a non-existent field."
+        """An attribute error is raised if you invoke a non-existent field."""
         Example = ObjCClass("Example")
 
         obj1 = Example.alloc().init()
@@ -663,7 +663,7 @@ class RubiconTest(unittest.TestCase):
             obj1.field_doesnt_exist
 
     def test_non_existent_method(self):
-        "An attribute error is raised if you invoke a non-existent method."
+        """An attribute error is raised if you invoke a non-existent method."""
         Example = ObjCClass("Example")
 
         obj1 = Example.alloc().init()
@@ -677,7 +677,7 @@ class RubiconTest(unittest.TestCase):
             obj1.method_doesnt_exist()
 
     def test_non_existent_static_field(self):
-        "An attribute error is raised if you invoke a non-existent static field."
+        """An attribute error is raised if you invoke a non-existent static field."""
         Example = ObjCClass("Example")
 
         # Non-existent fields raise an error.
@@ -689,7 +689,7 @@ class RubiconTest(unittest.TestCase):
             Example.static_field_doesnt_exist
 
     def test_non_existent_static_method(self):
-        "An attribute error is raised if you invoke a non-existent static method."
+        """An attribute error is raised if you invoke a non-existent static method."""
         Example = ObjCClass("Example")
 
         # Non-existent methods raise an error.
@@ -701,7 +701,7 @@ class RubiconTest(unittest.TestCase):
             Example.static_method_doesnt_exist()
 
     def test_polymorphic_constructor(self):
-        "Check that the right constructor is activated based on arguments used"
+        """Check that the right constructor is activated based on arguments used"""
         Example = ObjCClass("Example")
 
         obj1 = Example.alloc().init()
@@ -722,7 +722,7 @@ class RubiconTest(unittest.TestCase):
             Example.alloc().initWithString_("Hello")
 
     def test_static_access_non_static(self):
-        "An instance field/method cannot be accessed from the static context"
+        """An instance field/method cannot be accessed from the static context"""
         Example = ObjCClass("Example")
 
         obj = Example.alloc().init()
@@ -734,7 +734,7 @@ class RubiconTest(unittest.TestCase):
             obj.get_staticIntField()
 
     def test_non_static_access_static(self):
-        "A static field/method cannot be accessed from an instance context"
+        """A static field/method cannot be accessed from an instance context"""
         Example = ObjCClass("Example")
 
         with self.assertRaises(AttributeError):
@@ -744,13 +744,13 @@ class RubiconTest(unittest.TestCase):
             Example.accessIntField()
 
     def test_string_argument(self):
-        "A method with a string argument can be passed."
+        """A method with a string argument can be passed."""
         Example = ObjCClass("Example")
         example = Example.alloc().init()
         self.assertEqual(example.duplicateString_("Wagga"), "WaggaWagga")
 
     def test_enum_argument(self):
-        "An enumerated type can be used as an argument."
+        """An enumerated type can be used as an argument."""
         Example = ObjCClass("Example")
 
         obj = Example.alloc().init()
@@ -777,19 +777,19 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(obj.accessIntField(), MyEnum.value4.value)
 
     def test_string_return(self):
-        "If a method or field returns a string, you get a Python string back"
+        """If a method or field returns a string, you get a Python string back"""
         Example = ObjCClass("Example")
         example = Example.alloc().init()
         self.assertEqual(example.toString(), "This is an ObjC Example object")
 
     def test_constant_string_return(self):
-        "If a method or field returns a *constant* string, you get a Python string back"
+        """If a method or field returns a *constant* string, you get a Python string back"""
         Example = ObjCClass("Example")
         example = Example.alloc().init()
         self.assertEqual(example.smiley(), "%-)")
 
     def test_number_return(self):
-        "If a method or field returns a NSNumber, it is not automatically converted to a Python number."
+        """If a method or field returns a NSNumber, it is not automatically converted to a Python number."""
         Example = ObjCClass("Example")
         example = Example.alloc().init()
 
@@ -801,13 +801,13 @@ class RubiconTest(unittest.TestCase):
         self.assertAlmostEqual(py_from_ns(tau), 2.0 * math.pi, 5)
 
     def test_float_method(self):
-        "A method with a float argument can be handled."
+        """A method with a float argument can be handled."""
         Example = ObjCClass("Example")
         example = Example.alloc().init()
         self.assertEqual(example.areaOfSquare_(1.5), 2.25)
 
     def test_float_method_send(self):
-        "A method with a float argument can be handled by send_message."
+        """A method with a float argument can be handled by send_message."""
         Example = ObjCClass("Example")
         example = Example.alloc().init()
         self.assertEqual(
@@ -818,13 +818,13 @@ class RubiconTest(unittest.TestCase):
         )
 
     def test_double_method(self):
-        "A method with a double argument can be handled."
+        """A method with a double argument can be handled."""
         Example = ObjCClass("Example")
         example = Example.alloc().init()
         self.assertAlmostEqual(example.areaOfCircle_(1.5), 1.5 * math.pi, 5)
 
     def test_double_method_send(self):
-        "A method with a double argument can be handled by send_message."
+        """A method with a double argument can be handled by send_message."""
         Example = ObjCClass("Example")
         example = Example.alloc().init()
         self.assertAlmostEqual(
@@ -840,7 +840,7 @@ class RubiconTest(unittest.TestCase):
         "Property handling doesn't work on OS X 10.9 (Mavericks) and earlier",
     )
     def test_decimal_method(self):
-        "A method with a NSDecimalNumber arguments can be handled."
+        """A method with a NSDecimalNumber arguments can be handled."""
         Example = ObjCClass("Example")
         example = Example.alloc().init()
 
@@ -851,7 +851,7 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(py_from_ns(result), Decimal("6.0"))
 
     def test_auto_struct_creation(self):
-        "Structs from method signatures are created automatically."
+        """Structs from method signatures are created automatically."""
         Example = ObjCClass("Example")
 
         types.unregister_encoding_all(b"{simple=ii}")
@@ -879,7 +879,7 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(cast(ret.field_3, c_void_p).value, None)
 
     def test_sequence_arg_to_struct(self):
-        "Sequence arguments are converted to structures."
+        """Sequence arguments are converted to structures."""
         Example = ObjCClass("Example")
 
         ret = Example.extractSimpleStruct(([9, 8, 7, 6], None, (987, 654), None))
@@ -889,7 +889,7 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(ret.field_1, 654)
 
     def test_struct_return(self):
-        "Methods returning structs of different sizes by value can be handled."
+        """Methods returning structs of different sizes by value can be handled."""
         Example = ObjCClass("Example")
         example = Example.alloc().init()
 
@@ -903,7 +903,7 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(example.largeStruct().x, b"abcdefghijklmnop")
 
     def test_struct_return_send(self):
-        "Methods returning structs of different sizes by value can be handled when using send_message."
+        """Methods returning structs of different sizes by value can be handled when using send_message."""
         Example = ObjCClass("Example")
         example = Example.alloc().init()
 
@@ -925,7 +925,7 @@ class RubiconTest(unittest.TestCase):
         )
 
     def test_object_return(self):
-        "If a method or field returns an object, you get an instance of that type returned"
+        """If a method or field returns an object, you get an instance of that type returned"""
         Example = ObjCClass("Example")
         example = Example.alloc().init()
 
@@ -1001,7 +1001,7 @@ class RubiconTest(unittest.TestCase):
         self.assertIsNot(repr(tester), None)
 
     def test_duplicate_class_registration(self):
-        "If you define a class name twice in the same runtime, you get an error."
+        """If you define a class name twice in the same runtime, you get an error."""
 
         # First definition should work.
         class MyClass(NSObject):
@@ -1015,7 +1015,7 @@ class RubiconTest(unittest.TestCase):
                 pass
 
     def test_interface(self):
-        "An ObjC protocol implementation can be defined in Python."
+        """An ObjC protocol implementation can be defined in Python."""
 
         Callback = ObjCProtocol("Callback")
         results = {}
@@ -1123,7 +1123,7 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(r.size.height, 78)
 
     def test_class_properties(self):
-        "A Python class can have ObjC properties with synthesized getters and setters."
+        """A Python class can have ObjC properties with synthesized getters and setters."""
 
         NSURL = ObjCClass("NSURL")
 
@@ -1368,7 +1368,7 @@ class RubiconTest(unittest.TestCase):
         )
 
     def test_function_NSEdgeInsetsMake(self):
-        "Python can invoke NSEdgeInsetsMake to create NSEdgeInsets."
+        """Python can invoke NSEdgeInsetsMake to create NSEdgeInsets."""
 
         insets = NSEdgeInsets(0.0, 1.1, 2.2, 3.3)
         other_insets = NSEdgeInsetsMake(0.0, 1.1, 2.2, 3.3)
@@ -1383,13 +1383,13 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(insets.right, other_insets.right)
 
     def test_objc_const(self):
-        "objc_const works."
+        """objc_const works."""
 
         string_const = objc_const(rubiconharness, "SomeGlobalStringConstant")
         self.assertEqual(str(string_const), "Some global string constant")
 
     def test_interface_return_struct(self):
-        "An ObjC protocol implementation that returns values by struct can be defined in Python."
+        """An ObjC protocol implementation that returns values by struct can be defined in Python."""
 
         results = {}
         Thing = ObjCClass("Thing")
@@ -1663,7 +1663,7 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(attr1.retainCount(), 1, "weak property value was released")
 
     def test_partial_with_override(self):
-        "If one method in a partial is overridden, that doesn't impact lookup of other partial targets"
+        """If one method in a partial is overridden, that doesn't impact lookup of other partial targets"""
         SpecificExample = ObjCClass("SpecificExample")
 
         obj = SpecificExample.alloc().init()
@@ -1677,7 +1677,7 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(obj.baseIntField, 2)
 
     def test_stale_instance_cache(self):
-        "Instances returned by the ObjCInstance cache are checked for staleness (#249)"
+        """Instances returned by the ObjCInstance cache are checked for staleness (#249)"""
         # Wrap 2 classes with different method lists
         Example = ObjCClass("Example")
         Thing = ObjCClass("Thing")
@@ -1705,7 +1705,7 @@ class RubiconTest(unittest.TestCase):
             self.fail("Stale wrapper returned")
 
     def test_stale_instance_cache_implicit(self):
-        "Implicit instances returned by the ObjCInstance cache are checked for staleness (#249)"
+        """Implicit instances returned by the ObjCInstance cache are checked for staleness (#249)"""
         # Wrap 2 classes with different method lists
         Example = ObjCClass("Example")
         Thing = ObjCClass("Thing")
@@ -1741,7 +1741,7 @@ class RubiconTest(unittest.TestCase):
             self.fail("Stale wrapper returned")
 
     def test_compatible_class_name_change(self):
-        "If the class name changes in a compatible way, the wrapper isn't recreated (#257)"
+        """If the class name changes in a compatible way, the wrapper isn't recreated (#257)"""
         Example = ObjCClass("Example")
 
         pre_init = Example.alloc()
@@ -1759,7 +1759,7 @@ class RubiconTest(unittest.TestCase):
         assert id(pre_init) == id(post_init)
 
     def test_threaded_wrapper_creation(self):
-        "If 2 threads try to create a wrapper for the same object, only 1 wrapper is created (#251)"
+        """If 2 threads try to create a wrapper for the same object, only 1 wrapper is created (#251)"""
         # Create an ObjC instance, and keep a track of the memory address
         Example = ObjCClass("Example")
         obj = Example.alloc().init()
@@ -1798,7 +1798,8 @@ class RubiconTest(unittest.TestCase):
             self.assertEqual(id(wrappers[0]), id(wrappers[1]))
 
     def test_threaded_method_cache(self):
-        "If 2 threads try to access a method on the same object, there's no race condition populating the cache (#252)"
+        """If 2 threads try to access a method on the same object,
+        there's no race condition populating the cache (#252)"""
         # Wrap a class with lots of methods, and create the instance
         Example = ObjCClass("Example")
         obj = Example.alloc().init()
@@ -1830,7 +1831,8 @@ class RubiconTest(unittest.TestCase):
             thread.join()
 
     def test_threaded_accessor_cache(self):
-        "If 2 threads try to access an accessor on the same object, there's no race condition populating the cache (#252)"
+        """If 2 threads try to access an accessor on the same object,
+        there's no race condition populating the cache (#252)"""
         # Wrap a class with lots of methods, and create the instance
         Example = ObjCClass("Example")
         obj = Example.alloc().init()
@@ -1862,7 +1864,8 @@ class RubiconTest(unittest.TestCase):
             thread.join()
 
     def test_threaded_mutator_cache(self):
-        "If 2 threads try to access an mutator on the same object, there's no race condition populating the cache (#252)"
+        """If 2 threads try to access a mutator on the same object,
+        there's no race condition populating the cache (#252)"""
         # Wrap a class with lots of methods, and create the instance
         Example = ObjCClass("Example")
         obj = Example.alloc().init()


### PR DESCRIPTION
## Changes
- Remove unnecessary `noqa` markers
- Simplify `flake8` configuration
  - Remove `max-complexity`.....20 is a little high and I'm guessing someone was just trying to disable the check
  - Use [default](https://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-ignore) list of checks to `exclude`
    - E266 - Too many leading '#' for block comment
      - This doesn't seem to be relevant anymore
    - E501 - Line too long
      -  Added `noqa` markers where appropriate....or broke the line
    - W503 - Line break occurred before a binary operator
      - In the default list of excluded checks

## Notes
This one is a little different from the others since I'm making code changes. If you don't want to introduce these changes for the sake of a linter, I definitely understand and can just put `E501` back in the ignore list....although, I think it's better if that check actually runs.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
