### PR TITLE
Use an implicit namespace package, rather than the `pkg_resources` API.

### DIFF
--- a/changes/292.bugfix.rst
+++ b/changes/292.bugfix.rst
@@ -1,0 +1,1 @@
+Rubicon now uses an implicit namespace package, instead of relying on the deprecated ``pkg_resources`` API.

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ long_description_content_type = text/x-rst
 
 [options]
 python_requires = >=3.7
-packages = find:
+packages = find_namespace:
 package_dir =
     = src
 install_requires =
@@ -40,6 +40,7 @@ install_requires =
 
 [options.packages.find]
 where = src
+include = rubicon.*
 
 [options.extras_require]
 dev =

--- a/src/rubicon/__init__.py
+++ b/src/rubicon/__init__.py
@@ -1,7 +1,0 @@
-try:
-    # If we're on iOS, we won't have pkg-resources; but then,
-    # we won't need to register the namespace package, either.
-    # Ignore the error if it occurs.
-    __import__("pkg_resources").declare_namespace(__name__)
-except ImportError:
-    pass


### PR DESCRIPTION
Use the PEP420 namespace package interface, rather than the deprecated `pkg_resources` API provided by setuptools.

Fixes #292.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
