### PR TITLE
Further cleanup of spelling docs

### DIFF
--- a/docs/background/releases.rst
+++ b/docs/background/releases.rst
@@ -9,10 +9,7 @@ Release History
 Bugfixes
 --------
 
-* Classes that undergo a class name change between ``alloc()`` and ``init()``
-  (e.g., ``NSWindow`` becomes ``NSKVONotifying_Window``) no longer trigger
-  instance cache eviction logic. (`#258
-  <https://github.com/beeware/rubicon-objc/issues/258>`__)
+* Classes that undergo a class name change between ``alloc()`` and ``init()`` (e.g., ``NSWindow`` becomes ``NSKVONotifying_Window``) no longer trigger instance cache eviction logic. (`#258 <https://github.com/beeware/rubicon-objc/pull/258>`__)
 
 
 Misc
@@ -27,8 +24,7 @@ Misc
 Features
 --------
 
-* Support for Python 3.6 was dropped. (`#255
-  <https://github.com/beeware/rubicon-objc/issues/255>`__)
+* Support for Python 3.6 was dropped. (`#255 <https://github.com/beeware/rubicon-objc/pull/255>`__)
 
 Misc
 ----
@@ -47,16 +43,16 @@ Bugfixes
 
 * Background threads will no longer lock up on iOS when an asyncio event loop is
   in use. (`#228 <https://github.com/beeware/rubicon-objc/issues/228>`__)
-* The ObjCInstance cache no longer returns a stale wrapper objects if a memory
+* The ``ObjCInstance`` cache no longer returns a stale wrapper objects if a memory
   address is re-used by the Objective C runtime. (`#249
   <https://github.com/beeware/rubicon-objc/issues/249>`__)
 * It is now safe to open an asyncio event loop on a secondary thread. Previously
   this would work, but would intermittently fail with a segfault when then loop
   was closed. (`#250 <https://github.com/beeware/rubicon-objc/issues/250>`__)
 * A potential race condition that would lead to duplicated creation on
-  ObjCInstance wrapper objects has been resolved. (`#251
+  ``ObjCInstance`` wrapper objects has been resolved. (`#251
   <https://github.com/beeware/rubicon-objc/issues/251>`__)
-* A race condition associated with populating the ObjCClass method/property
+* A race condition associated with populating the ``ObjCClass`` method/property
   cache has been resolved. (`#252
   <https://github.com/beeware/rubicon-objc/issues/252>`__)
 
@@ -73,16 +69,13 @@ Misc
 Features
 --------
 
-* Support for Python 3.11 has been added. (`#224
-  <https://github.com/beeware/rubicon-objc/issues/224>`__)
-* Support for Python 3.12 has been added. (`#231
-  <https://github.com/beeware/rubicon-objc/issues/231>`__)
+* Support for Python 3.11 has been added. (`#224 <https://github.com/beeware/rubicon-objc/pull/224>`__)
+* Support for Python 3.12 has been added. (`#231 <https://github.com/beeware/rubicon-objc/pull/231>`__)
 
 Bugfixes
 --------
 
-* Enforce usage of `argtypes` when calling `send_super`. (`#220
-  <https://github.com/beeware/rubicon-objc/issues/220>`__)
+* Enforce usage of `argtypes` when calling `send_super`. (`#220 <https://github.com/beeware/rubicon-objc/pull/220>`__)
 * The check identifying the architecture on which Rubicon is running has been
   corrected for x86_64 simulators using a recent Python-Apple-support releases.
   (`#235 <https://github.com/beeware/rubicon-objc/issues/235>`__)
@@ -100,21 +93,16 @@ Features
 ^^^^^^^^
 
 * Added ``autoreleasepool`` context manager to mimic Objective-C
-  ``@autoreleasepool`` blocks. (`#213
-  <https://github.com/beeware/rubicon-objc/issues/213>`__)
-
+  ``@autoreleasepool`` blocks. (`#213 <https://github.com/beeware/rubicon-objc/pull/213>`__)
 * Allow storing Python objects in Objective-C properties declared with
-  ``@objc_property``. (`#214
-  <https://github.com/beeware/rubicon-objc/issues/214>`__)
-
-* Added support for Python 3.10. (`#218
-  <https://github.com/beeware/rubicon-objc/issues/218>`__)
+  ``@objc_property``. (`#214 <https://github.com/beeware/rubicon-objc/pull/214>`__)
+* Added support for Python 3.10. (`#218 <https://github.com/beeware/rubicon-objc/pull/218>`__)
 
 Bugfixes
 ^^^^^^^^
 
 * Raise ``TypeError`` when trying to declare a weak property of a non-object
-  type. (`#215 <https://github.com/beeware/rubicon-objc/issues/215>`__)
+  type. (`#215 <https://github.com/beeware/rubicon-objc/pull/215>`__)
 
 * Corrected handling of methods when a class overrides a method defined in a
   grandparent. (`#216 <https://github.com/beeware/rubicon-objc/issues/216>`__)
@@ -126,21 +114,13 @@ Bugfixes
 Features
 ^^^^^^^^
 
-* Added official support for Python 3.9. (`#193
-  <https://github.com/beeware/rubicon-objc/issues/193>`__)
-
-* Added official support for macOS 11 (Big Sur). (`#195
-  <https://github.com/beeware/rubicon-objc/issues/195>`__)
-
+* Added official support for Python 3.9. (`#193 <https://github.com/beeware/rubicon-objc/pull/193>`__)
+* Added official support for macOS 11 (Big Sur). (`#195 <https://github.com/beeware/rubicon-objc/pull/195>`__)
 * Autorelease Objective-C instances when the corresponding Python instance is
   destroyed. (`#200 <https://github.com/beeware/rubicon-objc/issues/200>`__)
-
 * Improved memory management when a Python instance is assigned to a new
-  ``ObjCInstance`` attribute. (`#209
-  <https://github.com/beeware/rubicon-objc/issues/209>`__)
-
-* Added support to declare weak properties on custom Objective-C classes. (`#210
-  <https://github.com/beeware/rubicon-objc/issues/210>`__)
+  ``ObjCInstance`` attribute. (`#209 <https://github.com/beeware/rubicon-objc/pull/209>`__)
+* Added support to declare weak properties on custom Objective-C classes. (`#210 <https://github.com/beeware/rubicon-objc/issues/210>`__)
 
 Bugfixes
 ^^^^^^^^
@@ -148,26 +128,16 @@ Bugfixes
 * Fixed incorrect behavior of :class:`~rubicon.objc.api.Block` when trying to
   create a block with no arguments and using explicit types. This previously
   caused an incorrect exception about missing argument types; now a ``no-arg``
-  block is created as expected. (`#153
-  <https://github.com/beeware/rubicon-objc/issues/153>`__)
-
+  block is created as expected. (`#153 <https://github.com/beeware/rubicon-objc/issues/153>`__)
 * Fixed handling of type annotations when passing a bound Python method into
-  :class:`~rubicon.objc.api.Block`. (`#153
-  <https://github.com/beeware/rubicon-objc/issues/153>`__)
-
+  :class:`~rubicon.objc.api.Block`. (`#153 <https://github.com/beeware/rubicon-objc/issues/153>`__)
 * A cooperative entry point for starting event loop has been added. This corrects
-  a problem seen when using Python 3.8 on iOS. (`#182
-  <https://github.com/beeware/rubicon-objc/issues/182>`__)
-
-* Improved performance of Objective-C method calls and
-  :class:`~rubicon.objc.api.ObjCInstance` creation in many cases. (`#183
-  <https://github.com/beeware/rubicon-objc/issues/183>`__)
-
-* Fix calling of signal handlers added to the asyncio loop with CFRunLoop
+  a problem seen when using Python 3.8 on iOS. (`#182 <https://github.com/beeware/rubicon-objc/pull/182>`__)
+* Improved performance of Objective-C method calls and :class:`~rubicon.objc.api.ObjCInstance` creation in many cases.
+  (`#183 <https://github.com/beeware/rubicon-objc/issues/183>`__)
+* Fix calling of signal handlers added to the asyncio loop with ``CFRunLoop``
   integration. (`#202 <https://github.com/beeware/rubicon-objc/issues/202>`__)
-
-* Allow restarting a stopped event loop. (`#205
-  <https://github.com/beeware/rubicon-objc/issues/205>`__)
+* Allow restarting a stopped event loop. (`#205 <https://github.com/beeware/rubicon-objc/pull/205>`__)
 
 Deprecations and Removals
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -203,17 +173,12 @@ Deprecations and Removals
   Rubicon will continue to support macOS 10.14 and earlier on a best-effort
   basis, even though compatibility is no longer tested automatically. If you
   encounter any bugs or other problems with Rubicon on these older macOS
-  versions, please report them! (`#197
-  <https://github.com/beeware/rubicon-objc/issues/197>`__)
+  versions, please report them! (`#197 <https://github.com/beeware/rubicon-objc/issues/197>`__)
 
 Misc
 ^^^^
 
-* `#185 <https://github.com/beeware/rubicon-objc/issues/185>`_,
-  `#189 <https://github.com/beeware/rubicon-objc/issues/189>`_,
-  `#194 <https://github.com/beeware/rubicon-objc/issues/194>`_,
-  `#196 <https://github.com/beeware/rubicon-objc/issues/196>`_,
-  `#208 <https://github.com/beeware/rubicon-objc/issues/208>`_
+* #185, #189, #194, #196, #208
 
 
 0.4.0 (2020-07-04)
@@ -223,21 +188,21 @@ Features
 ^^^^^^^^
 
 * Added macOS 10.15 (Catalina) to the test matrix.
-  (`#145 <https://github.com/beeware/rubicon-objc/issues/145>`__)
+  (`#145 <https://github.com/beeware/rubicon-objc/pull/145>`__)
 * Added :pep:`517` and :pep:`518` build system metadata to ``pyproject.toml``.
-  (`#156 <https://github.com/beeware/rubicon-objc/issues/156>`__)
+  (`#156 <https://github.com/beeware/rubicon-objc/pull/156>`__)
 * Added official support for Python 3.8.
-  (`#162 <https://github.com/beeware/rubicon-objc/issues/162>`__)
+  (`#162 <https://github.com/beeware/rubicon-objc/pull/162>`__)
 * Added a ``varargs`` keyword argument to
   :func:`~rubicon.objc.runtime.send_message` to allow calling variadic methods
-  more safely. (`#174 <https://github.com/beeware/rubicon-objc/issues/174>`__)
+  more safely. (`#174 <https://github.com/beeware/rubicon-objc/pull/174>`__)
 * Changed ``ObjCMethod`` to call methods using
   :func:`~rubicon.objc.runtime.send_message` instead of calling
   :class:`~rubicon.objc.runtime.IMP`\s directly. This is mainly an internal
   change and should not affect most existing code, although it may improve
   compatibility with Objective-C code that makes heavy use of runtime
   reflection and method manipulation (such as swizzling).
-  (`#177 <https://github.com/beeware/rubicon-objc/issues/177>`__)
+  (`#177 <https://github.com/beeware/rubicon-objc/pull/177>`__)
 
 Bugfixes
 ^^^^^^^^
@@ -252,37 +217,37 @@ Bugfixes
 * Corrected a slow memory leak caused every time an asyncio timed event handler
   triggered. (`#146 <https://github.com/beeware/rubicon-objc/issues/146>`__)
 * Fixed various minor issues in the build and packaging metadata.
-  (`#156 <https://github.com/beeware/rubicon-objc/issues/156>`__)
+  (`#156 <https://github.com/beeware/rubicon-objc/pull/156>`__)
 * Removed unit test that attempted to pass a struct with bit fields into a C
   function by value. Although this has worked in the past on x86 and x86_64,
   :mod:`ctypes` never officially supported this, and started generating an
   error in Python 3.7.6 and 3.8.1
   (see `bpo-39295 <https://bugs.python.org/issue39295>`__).
-  (`#157 <https://github.com/beeware/rubicon-objc/issues/157>`__)
+  (`#157 <https://github.com/beeware/rubicon-objc/pull/157>`__)
 * Corrected the invocation of ``NSApplication.terminate()`` when the
   :class:`~rubicon.objc.eventloop.CocoaLifecycle` is ended.
   (`#170 <https://github.com/beeware/rubicon-objc/issues/170>`__)
 * Fixed :func:`~rubicon.objc.runtime.send_message` not accepting
   :class:`~rubicon.objc.runtime.SEL` objects for the ``selector`` parameter.
   The documentation stated that this is allowed, but actually doing so caused
-  a type error. (`#177 <https://github.com/beeware/rubicon-objc/issues/177>`__)
+  a type error. (`#177 <https://github.com/beeware/rubicon-objc/pull/177>`__)
 
 Improved Documentation
 ^^^^^^^^^^^^^^^^^^^^^^
 
 * Added detailed :doc:`reference documentation </reference/index>` for all
   public APIs of :mod:`rubicon.objc`.
-  (`#118 <https://github.com/beeware/rubicon-objc/issues/118>`__)
+  (`#118 <https://github.com/beeware/rubicon-objc/pull/118>`__)
 * Added a :doc:`how-to guide for calling regular C functions
   </how-to/c-functions>` using :mod:`ctypes` and :mod:`rubicon.objc`.
-  (`#147 <https://github.com/beeware/rubicon-objc/issues/147>`__)
+  (`#147 <https://github.com/beeware/rubicon-objc/pull/147>`__)
 
 Deprecations and Removals
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Removed the i386 architecture from the test matrix. It is still supported on
   a best-effort basis, but compatibility is not tested automatically.
-  (`#139 <https://github.com/beeware/rubicon-objc/issues/139>`__)
+  (`#139 <https://github.com/beeware/rubicon-objc/pull/139>`__)
 * Tightened the API of :func:`~rubicon.objc.runtime.send_message`, removing
   some previously allowed shortcuts and features that were rarely used, or
   likely to be used by accident in an unsafe way.
@@ -330,29 +295,21 @@ Deprecations and Removals
   arguments now has to exactly match the number of ``argtypes``. Variadic
   methods can still be called, but the ``varargs`` now need to be passed as a
   list into the separate ``varargs`` keyword argument.
-  (`#174 <https://github.com/beeware/rubicon-objc/issues/174>`__)
+  (`#174 <https://github.com/beeware/rubicon-objc/pull/174>`__)
 * Removed the ``rubicon.objc.core_foundation`` module. This was an internal
   module with few remaining contents and should not have any external uses. If
   you need to call Core Foundation functions in your code, please load the
   framework yourself using ``load_library('CoreFoundation')`` and define the
   types and functions that you need.
-  (`#175 <https://github.com/beeware/rubicon-objc/issues/175>`__)
+  (`#175 <https://github.com/beeware/rubicon-objc/pull/175>`__)
 * Removed the ``ObjCMethod`` class from the public API, as there was no good
   way to use it from external code.
-  (`#177 <https://github.com/beeware/rubicon-objc/issues/177>`__)
+  (`#177 <https://github.com/beeware/rubicon-objc/pull/177>`__)
 
 Misc
 ^^^^
 
-* `#143 <https://github.com/beeware/rubicon-objc/issues/143>`_,
-  `#145 <https://github.com/beeware/rubicon-objc/issues/145>`_,
-  `#155 <https://github.com/beeware/rubicon-objc/issues/155>`_,
-  `#158 <https://github.com/beeware/rubicon-objc/issues/158>`_,
-  `#159 <https://github.com/beeware/rubicon-objc/issues/159>`_,
-  `#164 <https://github.com/beeware/rubicon-objc/issues/164>`_,
-  `#173 <https://github.com/beeware/rubicon-objc/issues/173>`_,
-  `#178 <https://github.com/beeware/rubicon-objc/issues/178>`_,
-  `#179 <https://github.com/beeware/rubicon-objc/issues/179>`_
+* #143, #145, #155, #158, #159, #164, #173, #178, #179
 
 
 0.3.1
@@ -461,11 +418,11 @@ Misc
 0.2.9
 -----
 
-* Improved handling of boolean types.
+* Improved handling of Boolean types.
 * Added support for using primitives as object values (e.g, as the key/value in
-  an NSDictonary).
-* Added support for passing Python lists as Objective-C NSArray arguments, and
-  Python dicts as Objective-C NSDictionary arguments.
+  an ``NSDictonary``).
+* Added support for passing Python lists as Objective-C ``NSArray`` arguments, and
+  Python dictionaries as Objective-C ``NSDictionary`` arguments.
 * Corrected support to storing strings and other objects as properties on
   Python-defined Objective-C classes.
 * Added support for creating Objective-C blocks from Python callables. (ojii)
@@ -476,7 +433,7 @@ Misc
   object constants in a DLL.
 * Added support for registering custom ``ObjCInstance`` subclasses to be used
   to represent Objective-C objects of specific classes.
-* Added support for integrating NSApplication and UIApplication event loops
+* Added support for integrating ``NSApplication`` and ``UIApplication`` event loops
   with Python's asyncio event loop.
 
 0.2.8

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -271,8 +271,6 @@ spelling_lang = "en_US"
 # Location of word list.
 spelling_word_list_filename = "spelling_wordlist"
 
-spelling_ignore_pypi_package_names = True
-
 # We mock the ctypes and ctypes.util modules during the documentation build,
 # so that Sphinx autodoc is able to import and inspect rubicon.objc even on systems without an Objective-C runtime.
 # For more details, see the docstring of _mocked_modules/ctypes/__init__.py.

--- a/docs/how-to/async.rst
+++ b/docs/how-to/async.rst
@@ -42,12 +42,12 @@ The last call (``loop.run_forever()``) will, as the name suggests, run forever
 - or, at least, until an event handler calls ``loop.stop()`` to terminate the
 event loop.
 
-Integrating asyncio with AppKit and NSApplication
-=================================================
+Integrating asyncio with AppKit and ``NSApplication``
+=====================================================
 
 If you're using AppKit and NSApplication, you don't just need to start the
-CoreFoundation event loop - you need to start the full NSApplication
-lifecycle. To do this, you pass the application instance into the call to
+CoreFoundation event loop - you need to start the full ``NSApplication``
+life cycle. To do this, you pass the application instance into the call to
 ``loop.run_forever()``::
 
     # Import the Event Loop Policy and lifecycle
@@ -76,7 +76,7 @@ Integrating asyncio with iOS and UIApplication
 ==============================================
 
 If you're using UIKit and UIApplication on iOS, you need to use the iOS
-lifecycle. To do this, you pass an ``iOSLifecycle`` object into the call to
+life cycle. To do this, you pass an ``iOSLifecycle`` object into the call to
 ``loop.run_forever()``::
 
     # Import the Event Loop Policy and lifecycle

--- a/docs/how-to/c-functions.rst
+++ b/docs/how-to/c-functions.rst
@@ -199,8 +199,8 @@ A complex example: ``dispatch_get_main_queue``
 As a final example, we'll look at the function ``dispatch_get_main_queue`` from
 the ``libdispatch`` library. This is a very complex function definition, which
 involves many of the concepts introduced above, as well as heavy use of C
-preprocessor macros. If you don't have a lot of experience with the C
-preprocessor, you may want to skip this section.
+pre-processor macros. If you don't have a lot of experience with the C
+pre-processor, you may want to skip this section.
 
 .. This example is based on the response to a question from the beeware/general Gitter chat: https://gitter.im/beeware/general?at=5b54e95357f4f664b794cde2
 
@@ -377,6 +377,6 @@ Further information
 -------------------
 
 * `cdecl.org <https://cdecl.org/>`_: An online service to translate C type syntax into more understandable English.
-* `cppreference.com <https://en.cppreference.com/>`_: A reference site about the standard C and C++ languages and libraries.
+* `cppreference.com <https://en.cppreference.com/w/>`_: A reference site about the standard C and C++ languages and libraries.
 * `Apple's reference documentation <https://developer.apple.com/documentation/>`_: Official API documentation for Apple platforms. Make sure to change the language to Objective-C in the top-right corner, otherwise you'll get Swift documentation, which can differ significantly from Objective-C.
 * macOS man pages, sections 2 and 3: Documentation for the C functions provided by macOS. View these using the ``man`` command, or by typing a function name into the search box of the macOS Terminal's Help menu.

--- a/docs/how-to/contribute-code.rst
+++ b/docs/how-to/contribute-code.rst
@@ -86,7 +86,7 @@ and re-commit the change.
     [bugfix e3e0f73] Minor change
     1 file changed, 4 insertions(+), 2 deletions(-)
 
-Rubicon uses `tox <https://tox.readthedocs.io/en/latest/>`__ to manage the
+Rubicon uses `tox <https://tox.wiki/en/latest/>`__ to manage the
 testing process. To set up a testing environment and run the full test suite,
 run:
 

--- a/docs/how-to/contribute-docs.rst
+++ b/docs/how-to/contribute-docs.rst
@@ -81,22 +81,6 @@ If a valid spelling of a word is identified as misspelled, then add the word to
 the list in ``docs/spelling_wordlist``. This will add the word to the
 spellchecker's
 
-If you get an error related to SSL certificate verification::
-
-    Exception occurred:
-      File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/ssl.py", line 1342, in do_handshake
-        self._sslobj.do_handshake()
-    ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1007)
-
-The root certificate on your machine is out of date. You can correct this by
-installing the Python package `certifi`, and using that package to provide your
-SSL root certificate:
-
-.. code-block:: bash
-
-  (venv) $ pip install certifi
-  (venv) $ export SSL_CERT_FILE=$(python -m certifi)
-
 Rebuilding all documentation
 ----------------------------
 

--- a/docs/how-to/internal/release.rst
+++ b/docs/how-to/internal/release.rst
@@ -74,8 +74,9 @@ The procedure for cutting a new release is as follows:
    new version. Ensure that the build completes; if there's a problem, you
    may need to correct the build configuration, roll back and re-tag the release.
 
-7. Edit the GitHub release. Add release notes (you can use the text generated
-   by towncrier). Check the pre-release checkbox (if necessary).
+7. Edit the GitHub release to add release notes. You can use the text generated
+   by Towncrier, but you'll need to update the format to Markdown, rather than
+   ReST. If necessary, check the pre-release checkbox.
 
 8. Double check everything, then click Publish. This will trigger a
    `publication workflow on GitHub

--- a/docs/how-to/type-mapping.rst
+++ b/docs/how-to/type-mapping.rst
@@ -149,7 +149,7 @@ other Objective-C and Python strings.
     in your code.
 
 If you have an :class:`~rubicon.objc.api.NSString`, and you need to pass it to
-a method that does a specific typecheck for :class:`str`, you can use
+a method that does a specific type check for :class:`str`, you can use
 ``str(nsstring)`` to convert the :class:`~rubicon.objc.api.NSString` to
 :class:`str`:
 

--- a/docs/reference/rubicon-objc-types.rst
+++ b/docs/reference/rubicon-objc-types.rst
@@ -253,7 +253,7 @@ error-prone and more readable than typing encodings out by hand.
 :class:`~ctypes.c_float`                  ``f``
 :class:`~ctypes.c_double`                 ``d``
 :class:`~ctypes.c_longdouble`             ``D``                      On ARM, :class:`~ctypes.c_longdouble` is an alias for :class:`~ctypes.c_double`, and will be encoded as such.
-:class:`~ctypes.c_char`                   ``c``                      Only when encoding. Decoding ``c`` produces :class:`~ctypes.c_byte`, to allow using ``signed char`` as a boolean value.
+:class:`~ctypes.c_char`                   ``c``                      Only when encoding. Decoding ``c`` produces :class:`~ctypes.c_byte`, to allow using ``signed char`` as a Boolean value.
 :class:`~ctypes.c_char_p`                 ``*``
 ``POINTER(c_char)``                       ``*``                      Only when encoding. Decoding ``*`` produces :class:`~ctypes.c_char_p` for easier use of C strings.
 ``POINTER(c_byte)``                       ``*``                      Only when encoding. Decoding ``*`` produces :class:`~ctypes.c_char_p` for easier use of C strings.

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -9,17 +9,27 @@ deallocating
 Deprecations
 dev
 Est
+getter
 getters
+hashable
 Iacta
 IDEs
 initializer
 inlines
+kwargs
 linters
+lookups
 macOS
+metaclass
 metaclasses
+namespace
+namespaces
 ObjC
 pre
+Pythonic
 rc
+runtime
+structs
 subclassed
 subclasses
 Subclasses
@@ -29,7 +39,9 @@ superclass
 superclasses
 Sur
 syntaxes
+Towncrier
 Unregister
+variadic
 Variadic
 Xcode
 

--- a/docs/tutorial/tutorial-2.rst
+++ b/docs/tutorial/tutorial-2.rst
@@ -116,7 +116,7 @@ What, no `__init__()`?
 
 You'll also notice that our example code *doesn't* have an `__init__()` method
 like you'd normally expect of Python code. As we're defining an Objective-C
-class, we need to follow the Objective-C object lifecycle - which means
+class, we need to follow the Objective-C object life cycle - which means
 defining initializer methods that are visible to the Objective-C runtime, and
 invoking them over that bridge.
 

--- a/src/rubicon/objc/eventloop.py
+++ b/src/rubicon/objc/eventloop.py
@@ -735,7 +735,7 @@ class CFLifecycle:
 
 
 class CocoaLifecycle:
-    """A lifecycle manager for Cocoa (``NSApplication``) apps."""
+    """A life cycle manager for Cocoa (``NSApplication``) apps."""
 
     def __init__(self, application):
         self._application = application
@@ -748,7 +748,7 @@ class CocoaLifecycle:
 
 
 class iOSLifecycle:
-    """A lifecycle manager for iOS (``UIApplication``) apps."""
+    """A life cycle manager for iOS (``UIApplication``) apps."""
 
     def start(self):
         libcf.CFRunLoopRun()

--- a/src/rubicon/objc/runtime.py
+++ b/src/rubicon/objc/runtime.py
@@ -81,7 +81,7 @@ def load_library(name):
 
     Internally, this function uses :func:`ctypes.util.find_library` to search
     for the library in the system-standard locations. If the library cannot be
-    found this way, it is attempted to load the library from certain hardcoded
+    found this way, it is attempted to load the library from certain hard-coded
     locations, as a fallback for systems where ``find_library`` does not work
     (such as iOS).
     """
@@ -1058,7 +1058,7 @@ def add_ivar(cls, name, vartype):
 
 
 def get_ivar(obj, varname, weak=False):
-    """Get the value of obj's ``ivar`` named varname.
+    """Get the value of obj's ``ivar`` named ``varname``.
 
     The returned object is a :mod:`ctypes` data object.
 
@@ -1092,7 +1092,7 @@ def get_ivar(obj, varname, weak=False):
 
 
 def set_ivar(obj, varname, value, weak=False):
-    """Set obj's ``ivar`` varname to value. If ``weak`` is ``True``, only a weak
+    """Set obj's ``ivar`` ``varname`` to value. If ``weak`` is ``True``, only a weak
     reference to the value is stored.
 
     value must be a :mod:`ctypes` data object whose type matches that of

--- a/tox.ini
+++ b/tox.ini
@@ -49,13 +49,8 @@ change_dir = docs
 passenv =
     # On macOS M1, you need to manually set the location of the PyEnchant
     # library:
-    #     export PYENCHANT_LIBRARY_PATH/opt/homebrew/lib/libenchant-2.2.dylib
+    #     export PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.2.dylib
     PYENCHANT_LIBRARY_PATH
-    # It is sometimes necessary to override the default certificate store
-    # so that PyPI can be contacted with XMLRPC:
-    #     pip install certifi
-    #     export SSL_CERT_FILE=$(python -m certifi)
-    SSL_CERT_FILE
 extras =
     docs
 commands =


### PR DESCRIPTION
The SSL error on macOS was caused because the PyPI name filter was turned on. This made every single one of the 440k names of PyPI packages a valid word in spelling. So... that needs to be turned off.

That removes the need for the SSL instructions in the contribution guide. 

It also reveals a bunch of additional spelling problems. The only ones that *aren't* legitimate are the ones tied to a package name; for those, I've adopted the policy of:
* If it's being used in a "code" context, use the name as a literal
* If it's being used in a "text" context, ensure preferred project naming and capitalisation is used.

I've also updated all the links that were raising redirects. Ideally, redirects could be raised as an error, but that doesn't appear to be an option with Sphinx.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
