### PR TITLE
Add support for `sphinx-copybutton`

### DIFF
--- a/changes/300.doc.rst
+++ b/changes/300.doc.rst
@@ -1,0 +1,1 @@
+All code blocks were updated to add a button to copy the relevant contents on to the user's clipboard.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,12 @@ sys.path.insert(0, os.path.abspath("../src"))
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ["sphinx.ext.autodoc", "sphinx_tabs.tabs", "sphinx.ext.intersphinx"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx_tabs.tabs",
+    "sphinx_copybutton",
+    "sphinx.ext.intersphinx",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -101,6 +106,40 @@ nitpick_ignore = [
     ("py:func", "rubicon.objc.types.NSMakeSize"),
     ("py:func", "rubicon.objc.types.UIEdgeInsetsMake"),
 ]
+
+# -- Options for copy button ---------------------------------------------------
+
+# virtual env prefix: (venv), (beeware-venv), (testenv)
+venv = r"\((?:(?:beeware-)?venv|testvenv)\)"
+# macOS and Linux shell prompt: $
+shell = r"\$"
+# win CMD prompt: C:\>, C:\...>
+cmd = r"C:\\>|C:\\\.\.\.>"
+# PowerShell prompt: PS C:\>, PS C:\...>
+ps = r"PS C:\\>|PS C:\\\.\.\.>"
+# zero or one whitespace char
+sp = r"\s?"
+
+# optional venv prefix
+venv_prefix = rf"(?:{venv})?"
+# one of the platforms' shell prompts
+shell_prompt = rf"(?:{shell}|{cmd}|{ps})"
+
+copybutton_prompt_text = "|".join(
+    [
+        # Python REPL
+        r">>>\s?",
+        r"\.\.\.\s?",
+        # IPython and Jupyter
+        # r"In \[\d*\]:\s?", r" {5,8}:\s?", r" {2,5}\.\.\.:\s?",
+        # Shell prompt
+        rf"{venv_prefix}{sp}{shell_prompt}{sp}",
+    ]
+)
+copybutton_prompt_is_regexp = True
+copybutton_remove_prompts = True
+copybutton_only_copy_prompt_lines = True
+copybutton_copy_empty_lines = False
 
 # -- Options for HTML output ---------------------------------------------------
 

--- a/docs/how-to/async.rst
+++ b/docs/how-to/async.rst
@@ -3,7 +3,7 @@ Asynchronous Programming with Rubicon
 =====================================
 
 One of the banner features of Python 3 is the introduction of native
-asynchronous programming, implemented in the `asyncio`.
+asynchronous programming, implemented in :mod:`asyncio`.
 
 For an introduction to the use of asynchronous programming, see `the
 documentation for the asyncio module
@@ -12,14 +12,14 @@ documentation for the asyncio module
 Integrating asyncio with CoreFoundation
 =======================================
 
-The asyncio module provides an event loop to coordinate asynchronous features.
-However, if you're running an Objective C GUI application, you probably
-already have an event loop - the one provided by CoreFoundation. This
-CoreFoundation event loop is then wrapped by `NSApplication` or
-`UIApplication` in end-user code.
+The :mod:`asyncio` module provides an event loop to coordinate asynchronous
+features. However, if you're running an Objective C GUI application, you
+probably already have an event loop - the one provided by CoreFoundation.
+This CoreFoundation event loop is then wrapped by ``NSApplication`` or
+``UIApplication`` in end-user code.
 
 However, you can't have two event loops running at the same time, so you need
-a way to integrate the two. Luckily, `asyncio` provides a way to customize
+a way to integrate the two. Luckily, :mod:`asyncio` provides a way to customize
 it's event loop so it can be integrated with other event sources.
 
 It does this using an Event Loop Policy. Rubicon provides an Core Foundation

--- a/docs/how-to/c-functions.rst
+++ b/docs/how-to/c-functions.rst
@@ -2,18 +2,31 @@
 Calling plain C functions from Python
 =====================================
 
-Most Objective-C APIs are exposed through Objective-C classes and methods, but some parts are implemented as plain C functions. You might also want to want to use a pure C library that provides no Objective-C interface at all. Calling C functions is quite different from calling Objective-C methods and requires some additional work, which will be explained in this how-to.
+Most Objective-C APIs are exposed through Objective-C classes and methods, but
+some parts are implemented as plain C functions. You might also want to want to
+use a pure C library that provides no Objective-C interface at all. Calling C
+functions is quite different from calling Objective-C methods and requires some
+additional work, which will be explained in this how-to.
 
 .. seealso::
 
-    The `ctypes tutorial <https://docs.python.org/3/library/ctypes.html#ctypes-tutorial>`_ in the Python documentation, which explains how to call C functions in general (without a specific focus on Apple platforms and Objective-C).
+    The `ctypes tutorial
+    <https://docs.python.org/3/library/ctypes.html#ctypes-tutorial>`_ in the
+    Python documentation, which explains how to call C functions in general
+    (without a specific focus on Apple platforms and Objective-C).
 
 A simple example: ``puts``
 --------------------------
 
-We'll start with a simple example: calling the ``puts`` function from the C standard library. ``puts`` takes a C string and outputs it to standard output --- it's the C equivalent of a simple ``print`` call.
+We'll start with a simple example: calling the ``puts`` function from the C
+standard library. ``puts`` takes a C string and outputs it to standard output
+--- it's the C equivalent of a simple ``print`` call.
 
-Before we can call the function, we need to look it up first. To do this, we need to find and load the library in which the function is defined. In the case of standard C functions, this is the standard C library, ``libc``. Because this library is commonly used, Rubicon already loads it by default and exposes it in Python as :attr:`rubicon.objc.runtime.libc`.
+Before we can call the function, we need to look it up first. To do this, we
+need to find and load the library in which the function is defined. In the case
+of standard C functions, this is the standard C library, ``libc``. Because this
+library is commonly used, Rubicon already loads it by default and exposes it in
+Python as :attr:`rubicon.objc.runtime.libc`.
 
 .. code-block:: python
 
@@ -23,9 +36,12 @@ Before we can call the function, we need to look it up first. To do this, we nee
 
 .. note::
 
-    For a list of all C libraries that Rubicon loads and exposes by default, see the :ref:`predefined-c-libraries` section of the :mod:`rubicon.objc.runtime` reference documentation.
+    For a list of all C libraries that Rubicon loads and exposes by default,
+    see the :ref:`predefined-c-libraries` section of the
+    :mod:`rubicon.objc.runtime` reference documentation.
 
-    To access a library that is not predefined by Rubicon, you can use the :func:`~rubicon.objc.runtime.load_library` function:
+    To access a library that is not predefined by Rubicon, you can use the
+    :func:`~rubicon.objc.runtime.load_library` function:
 
     .. code-block:: python
 
@@ -41,29 +57,43 @@ C functions are accessed as attributes on their library:
     >>> libc.puts
     <_FuncPtr object at 0x110178f20>
 
-However, unlike Objective-C methods, we cannot call C functions right away --- we must first declare the function's argument and return types. (Rubicon cannot do this automatically like with Objective-C methods, because plain C doesn't provide the runtime type information necessary for this.) This type information is found in C header files, in this case ``stdio.h`` (which defines standard C input/output functions, including ``puts``).
+However, unlike Objective-C methods, we cannot call C functions right away ---
+we must first declare the function's argument and return types. (Rubicon cannot
+do this automatically like with Objective-C methods, because plain C doesn't
+provide the runtime type information necessary for this.) This type information
+is found in C header files, in this case ``stdio.h`` (which defines standard C
+input/output functions, including ``puts``).
 
-The exact location of the macOS C headers varies depending on your version of macOS and the developer tools --- it is not a fixed path. To open the header directory in the Finder, run the following command in the terminal:
+The exact location of the macOS C headers varies depending on your version of
+macOS and the developer tools --- it is not a fixed path. To open the header
+directory in the Finder, run the following command in the terminal:
 
-.. code-block:: sh
+.. code-block:: console
 
     $ open "$(xcrun --show-sdk-path)/usr/include"
 
 .. note::
 
-    This command requires a version of the macOS developer tools to be installed. If you do not have Xcode or the command-line developer tools installed yet, run this command in the terminal to install the command-line developer tools:
+    This command requires a version of the macOS developer tools to be
+    installed. If you do not have Xcode or the command-line developer tools
+    installed yet, run this command in the terminal to install the command-line
+    developer tools:
 
-    .. code-block:: sh
+    .. code-block:: console
 
         $ xcode-select --install
 
-Once you have opened the relevant header file in a text editor, you need to search for the declaration of the function you're looking for. In the case of ``puts``, it looks like this:
+Once you have opened the relevant header file in a text editor, you need to
+search for the declaration of the function you're looking for. In the case of
+``puts``, it looks like this:
 
 .. code-block:: c
 
     int puts(const char *);
 
-This means that ``puts`` returns an ``int`` and takes a single argument of type ``const char *`` (a pointer to one or more characters, i.e. a C string). This translates to the following Python ``ctypes`` code:
+This means that ``puts`` returns an ``int`` and takes a single argument of type
+``const char *`` (a pointer to one or more characters, i.e. a C string). This
+translates to the following Python ``ctypes`` code:
 
 .. code-block:: python
 
@@ -71,9 +101,14 @@ This means that ``puts`` returns an ``int`` and takes a single argument of type 
     >>> libc.puts.restype = c_int
     >>> libc.puts.argtypes = [c_char_p]
 
-Now that we have provided all of the necessary type information, we can call ``libc.puts``.
+Now that we have provided all of the necessary type information, we can call
+``libc.puts``.
 
-For the ``c_char_p`` argument, we pass a byte string with the message we want to print out. ``ctypes`` automatically converts the byte string object to a ``c_char_p`` (``char *``) as the C function expects it. The string specifically needs to be a byte string (``bytes``), because C's ``char *`` strings are byte-based, unlike normal Python strings (``str``), which are Unicode-based.
+For the ``c_char_p`` argument, we pass a byte string with the message we want
+to print out. ``ctypes`` automatically converts the byte string object to a
+``c_char_p`` (``char *``) as the C function expects it. The string specifically
+needs to be a byte string (``bytes``), because C's ``char *`` strings are
+byte-based, unlike normal Python strings (``str``), which are Unicode-based.
 
 .. code-block:: python
 
@@ -82,24 +117,54 @@ For the ``c_char_p`` argument, we pass a byte string with the message we want to
 
 .. note::
 
-    If you're running this code from an editor or IDE and don't see ``Hello!`` printed out, try running the code from a Python REPL in a terminal window instead. Some editors/IDEs, such as Python's IDLE, can only capture and display output produced by high-level Python functions (such as ``print``), but not output from low-level C functions (such as ``puts``).
+    If you're running this code from an editor or IDE and don't see ``Hello!``
+    printed out, try running the code from a Python REPL in a terminal window
+    instead. Some editors/IDEs, such as Python's IDLE, can only capture and
+    display output produced by high-level Python functions (such as ``print``),
+    but not output from low-level C functions (such as ``puts``).
 
-    The return value of ``puts`` is ignored in this example. It indicates whether or not the call was successful. If ``puts`` succeeds, it returns a non-negative integer (the exact value is not significant and has no defined meaning). If ``puts`` encounters an error, it returns the ``EOF`` constant (on Apple OSes, this is ``-1``).
+    The return value of ``puts`` is ignored in this example. It indicates
+    whether or not the call was successful. If ``puts`` succeeds, it returns a
+    non-negative integer (the exact value is not significant and has no defined
+    meaning). If ``puts`` encounters an error, it returns the ``EOF`` constant
+    (on Apple OSes, this is ``-1``).
 
-    The ``puts`` function generally doesn't fail, except for edge cases that are unlikely to happen in practice. With most other C functions, you need to be more careful about checking the return value, to make sure that errors from the function call are detected and handled. Unlike in Python, if you forget to check whether a C function call failed, any errors from that call are silently ignored, which often leads to bad behavior or crashes.
+    The ``puts`` function generally doesn't fail, except for edge cases that
+    are unlikely to happen in practice. With most other C functions, you need
+    to be more careful about checking the return value, to make sure that
+    errors from the function call are detected and handled. Unlike in Python,
+    if you forget to check whether a C function call failed, any errors from
+    that call are silently ignored, which often leads to bad behavior or
+    crashes.
 
-Most real examples of C functions are more complicated than ``puts``, but the basic procedure for calling them is the same: import or load the function's C library, set the function's return type and argument types based on the relevant header, and then call the function as needed.
+Most real examples of C functions are more complicated than ``puts``, but the
+basic procedure for calling them is the same: import or load the function's C
+library, set the function's return type and argument types based on the
+relevant header, and then call the function as needed.
 
-Each C library only needs to be imported/loaded once, and the ``restype`` and ``argtypes`` only need to be set once per function. This is usually done at module level near the beginning of the module, similar to Python imports.
+Each C library only needs to be imported/loaded once, and the ``restype`` and
+``argtypes`` only need to be set once per function. This is usually done at
+module level near the beginning of the module, similar to Python imports.
 
 Inline functions (e.g. ``NSLocationInRange``)
 ---------------------------------------------
 
-Regular C functions can be called as explained above, but there is also a second kind of C function that needs to be handled differently: inline functions. Unlike regular C functions, inline functions cannot be called through a library object at runtime. Instead, their implementation is only provided as source code in a header file.
+Regular C functions can be called as explained above, but there is also a
+second kind of C function that needs to be handled differently: inline
+functions. Unlike regular C functions, inline functions cannot be called
+through a library object at runtime. Instead, their implementation is only
+provided as source code in a header file.
 
-When an inline function is called from regular C code, the C compiler copies (inlines) the inline function's implementation into the calling code. To call an inline C function from Python, we need to do the same thing --- copy the code from the header into our own code --- but in addition we need to translate the C code from the header into equivalent Python/``ctypes`` code.
+When an inline function is called from regular C code, the C compiler copies
+(inlines) the inline function's implementation into the calling code. To call
+an inline C function from Python, we need to do the same thing --- copy the
+code from the header into our own code --- but in addition we need to
+translate the C code from the header into equivalent Python/``ctypes`` code.
 
-As an example we will use the function ``NSLocationInRange`` from the Foundation framework. This function checks whether an index lies inside a ``NSRange`` value. The definition of this function, from the Foundation header ``NSRange.h``, looks like this:
+As an example we will use the function ``NSLocationInRange`` from the
+Foundation framework. This function checks whether an index lies inside a
+``NSRange`` value. The definition of this function, from the Foundation header
+``NSRange.h``, looks like this:
 
 .. code-block:: objc
 
@@ -107,11 +172,19 @@ As an example we will use the function ``NSLocationInRange`` from the Foundation
         return (!(loc < range.location) && (loc - range.location) < range.length) ? YES : NO;
     }
 
-In this case, the translation to Python consists (roughly) of the following steps:
+In this case, the translation to Python consists (roughly) of the following
+steps:
 
-1. The outer part of the function definition needs to be translated to Python's ``def`` syntax. The return type and argument types can be omitted in the Python code --- because Python is dynamically typed, these explicit types are not needed.
-2. The ``YES`` and ``NO`` constants in the ``return`` expressions need to be replaced with their Python equivalents, ``True`` and ``False``.
-3. Some operators in the ``return`` expression need to be changed: C ``!cond`` translates to Python ``not cond``, C ``left && right`` becomes ``left and right``, and C ``cond ? true_val : false_val`` becomes ``true_val if cond else false_val``.
+1. The outer part of the function definition needs to be translated to Python's
+   ``def`` syntax. The return type and argument types can be omitted in the
+   Python code --- because Python is dynamically typed, these explicit types
+   are not needed.
+2. The ``YES`` and ``NO`` constants in the ``return`` expressions need to be
+   replaced with their Python equivalents, ``True`` and ``False``.
+3. Some operators in the ``return`` expression need to be changed: C ``!cond``
+   translates to Python ``not cond``, C ``left && right`` becomes
+   ``left and right``, and C ``cond ? true_val : false_val`` becomes
+   ``true_val if cond else false_val``.
 
 The translated Python code looks like this:
 
@@ -120,11 +193,17 @@ The translated Python code looks like this:
     def NSLocationInRange(loc, range):
         return True if (not (loc < range.location) and (loc - range.location) < range.length) else False
 
-You can then put this translated function into your Python code and call it in place of the corresponding C inline function.
+You can then put this translated function into your Python code and call it in
+place of the corresponding C inline function.
 
 .. note::
 
-    Python code translated from C like this is sometimes more complicated than necessary and can be simplified. In this case for example, ``True if cond else False`` can be simplified to just ``cond``, ``not (x < y)`` can be simplified to ``x >= y``, and a few redundant parentheses can be removed. A cleaner version of the translated code might look like this:
+    Python code translated from C like this is sometimes more complicated than
+    necessary and can be simplified. In this case for example,
+    ``True if cond else False`` can be simplified to just ``cond``,
+    ``not (x < y)`` can be simplified to ``x >= y``, and a few redundant
+    parentheses can be removed. A cleaner version of the translated code might
+    look like this:
 
     .. code-block:: python
 
@@ -134,13 +213,19 @@ You can then put this translated function into your Python code and call it in p
 Global variables and constants (e.g. ``NSFoundationVersionNumber``)
 -------------------------------------------------------------------
 
-Some C libraries expose not just functions, but also global variables. An example of this is the Foundation framework, which defines the global variable ``NSFoundationVersionNumber`` in ``<Foundation/NSObjCRuntime.h>``:
+Some C libraries expose not just functions, but also global variables. An
+example of this is the Foundation framework, which defines the global variable
+``NSFoundationVersionNumber`` in ``<Foundation/NSObjCRuntime.h>``:
 
 .. code-block:: objc
 
     FOUNDATION_EXPORT double NSFoundationVersionNumber;
 
-Like functions, global variables are accessed via the library that they are defined by. The syntax is somewhat different for global variables though - instead of reading them directly as attributes of the library object, you use the ``in_dll`` method of the variable's *type*. (Every ``ctypes`` type has an ``in_dll`` method.)
+Like functions, global variables are accessed via the library that they are
+defined by. The syntax is somewhat different for global variables though -
+instead of reading them directly as attributes of the library object, you use
+the ``in_dll`` method of the variable's *type*. (Every ``ctypes`` type has an
+``in_dll`` method.)
 
 .. code-block:: python
 
@@ -150,7 +235,10 @@ Like functions, global variables are accessed via the library that they are defi
     >>> NSFoundationVersionNumber
     c_double(1575.23)
 
-Note that ``in_dll`` doesn't return the variable's value directly - instead it returns a ``ctypes`` data object that has the variable's type, in this case ``c_double``. To access the variable's actual value, you can use the data object's ``value`` attribute:
+Note that ``in_dll`` doesn't return the variable's value directly - instead it
+returns a ``ctypes`` data object that has the variable's type, in this case
+``c_double``. To access the variable's actual value, you can use the data
+object's ``value`` attribute:
 
 .. code-block:: python
 
@@ -160,13 +248,18 @@ Note that ``in_dll`` doesn't return the variable's value directly - instead it r
 Objective-C object constants
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A special case of global variables is often found in Objective-C libraries: object constants. These are global Objective-C object variables with a ``const`` modifier, meaning that they cannot be modified. Constants of type ``NSString *`` are especially common and can be found in many places, such as Foundation's ``<Foundation/NSMetadataAttribute.h>``:
+A special case of global variables is often found in Objective-C libraries:
+object constants. These are global Objective-C object variables with a
+``const`` modifier, meaning that they cannot be modified. Constants of type
+``NSString *`` are especially common and can be found in many places, such as
+Foundation's ``<Foundation/NSMetadataAttribute.h>``:
 
 .. code-block:: objc
 
     FOUNDATION_EXPORT NSString * const NSMetadataItemFSNameKey;
 
-Because they are so common, Rubicon provides the convenience function ``objc_const`` specifically for accessing Objective-C object constants:
+Because they are so common, Rubicon provides the convenience function
+``objc_const`` specifically for accessing Objective-C object constants:
 
 .. code-block:: python
 
@@ -178,7 +271,11 @@ Because they are so common, Rubicon provides the convenience function ``objc_con
 
 .. note::
 
-    Sometimes it's not obvious that a constant is an Objective-C object, because its actual type is hidden behind a ``typedef``. This is common with the "extensible string enum" pattern, where a set of related string constants are defined together. An example can be found in ``<Foundation/NSCalendar.h>``:
+    Sometimes it's not obvious that a constant is an Objective-C object,
+    because its actual type is hidden behind a ``typedef``. This is common with
+    the "extensible string enum" pattern, where a set of related string
+    constants are defined together. An example can be found in
+    ``<Foundation/NSCalendar.h>``:
 
     .. code-block:: objc
 
@@ -189,9 +286,12 @@ Because they are so common, Rubicon provides the convenience function ``objc_con
         FOUNDATION_EXPORT NSCalendarIdentifier const NSCalendarIdentifierChinese;
         // ... many more ...
 
-    Even though the constants use the type name ``NSCalendarIdentifier``, their actual type is still ``NSString *``, based on the ``typedef`` before.
+    Even though the constants use the type name ``NSCalendarIdentifier``, their
+    actual type is still ``NSString *``, based on the ``typedef`` before.
 
-    In some cases, constants use a ``typedef`` from a different header (or even a different library) than the one defining the constants, which can make it even harder to tell that they are actually Objective-C objects.
+    In some cases, constants use a ``typedef`` from a different header (or even
+    a different library) than the one defining the constants, which can make it
+    even harder to tell that they are actually Objective-C objects.
 
 A complex example: ``dispatch_get_main_queue``
 ----------------------------------------------
@@ -204,7 +304,8 @@ pre-processor, you may want to skip this section.
 
 .. This example is based on the response to a question from the beeware/general Gitter chat: https://gitter.im/beeware/general?at=5b54e95357f4f664b794cde2
 
-First, we need to look at the function's definition, which is found in the header ``<dispatch/queue.h>``:
+First, we need to look at the function's definition, which is found in the
+header ``<dispatch/queue.h>``:
 
 .. code-block:: objc
 
@@ -215,23 +316,39 @@ First, we need to look at the function's definition, which is found in the heade
         return DISPATCH_GLOBAL_OBJECT(dispatch_queue_main_t, _dispatch_main_q);
     }
 
-This is an inline function, which you can see based on the fact that it has a function body and the ``DISPATCH_INLINE``/``DISPATCH_ALWAYS_INLINE`` attributes. This means that we cannot look it up directly using ``ctypes`` - instead we have to translate the function body from C to Python.
+This is an inline function, which you can see based on the fact that it has a
+function body and the ``DISPATCH_INLINE``/``DISPATCH_ALWAYS_INLINE``
+attributes. This means that we cannot look it up directly using ``ctypes`` -
+instead we have to translate the function body from C to Python.
 
-We can ignore the first line of the function definition - they contain function attributes intended for the compiler, which we don't need. The second and third line indicate the function's signature - it takes no arguments and returns a value of type ``dispatch_queue_main_t``.
+We can ignore the first line of the function definition - they contain function
+attributes intended for the compiler, which we don't need. The second and third
+line indicate the function's signature - it takes no arguments and returns a
+value of type ``dispatch_queue_main_t``.
 
-The body is a little more complex: it uses ``DISPATCH_GLOBAL_OBJECT``, which is actually a C macro. Its definition can be found in ``<dispatch/object.h>``:
+The body is a little more complex: it uses ``DISPATCH_GLOBAL_OBJECT``, which is
+actually a C macro. Its definition can be found in ``<dispatch/object.h>``:
 
 .. code-block:: objc
 
     #define DISPATCH_GLOBAL_OBJECT(type, object) ((OS_OBJECT_BRIDGE type)&(object))
 
-If we substitute the macro's parameters (``type`` and ``object``) for their real values in our case (``dispatch_queue_main_t`` and ``_dispatch_main_q``), we get the expression ``((OS_OBJECT_BRIDGE dispatch_queue_main_t)&(_dispatch_main_q))``. ``OS_OBJECT_BRIDGE`` is also a macro, this time from ``<os/object.h>``:
+If we substitute the macro's parameters (``type`` and ``object``) for their
+real values in our case (``dispatch_queue_main_t`` and ``_dispatch_main_q``),
+we get the expression
+``((OS_OBJECT_BRIDGE dispatch_queue_main_t)&(_dispatch_main_q))``.
+``OS_OBJECT_BRIDGE`` is also a macro, this time from ``<os/object.h>``:
 
 .. code-block:: objc
 
     #define OS_OBJECT_BRIDGE __bridge
 
-It expands to ``__bridge``, which is an attribute related to Objective-C's automatic reference counting (ARC) feature. In the context of Rubicon, ARC is not relevant (Rubicon performs its own reference management for Objective-C objects), so we can ignore this attribute. This leaves us with the expression ``((dispatch_queue_main_t)&(_dispatch_main_q))``, which we can substitute for the macro call in our original function:
+It expands to ``__bridge``, which is an attribute related to Objective-C's
+automatic reference counting (ARC) feature. In the context of Rubicon, ARC is
+not relevant (Rubicon performs its own reference management for Objective-C
+objects), so we can ignore this attribute. This leaves us with the expression
+``((dispatch_queue_main_t)&(_dispatch_main_q))``, which we can substitute for
+the macro call in our original function:
 
 .. code-block:: objc
 
@@ -241,18 +358,26 @@ It expands to ``__bridge``, which is an attribute related to Objective-C's autom
         return (dispatch_queue_main_t)&(_dispatch_main_q));
     }
 
-With the macro expansion done, we can now see what the function does: it takes a pointer to the global variable ``_dispatch_main_q`` and casts it to the type ``dispatch_queue_main_t``.
+With the macro expansion done, we can now see what the function does: it takes
+a pointer to the global variable ``_dispatch_main_q`` and casts it to the type
+``dispatch_queue_main_t``.
 
-First, let's look at the definition of the ``_dispatch_main_q`` variable, from ``<dispatch/queue.h>``:
+First, let's look at the definition of the ``_dispatch_main_q`` variable, from
+``<dispatch/queue.h>``:
 
 .. code-block:: objc
 
     DISPATCH_EXPORT
     struct dispatch_queue_s _dispatch_main_q;
 
-The variable's type, ``struct dispatch_queue_s``, is an *opaque* structure type - it is not defined in any public header. This means that we don't know what fields the structure has, or even how large it is. As a result, we cannot perform any operations on the structure itself, but we can work with *pointers* to the structure - which is exactly what ``dispatch_get_main_queue`` does.
+The variable's type, ``struct dispatch_queue_s``, is an *opaque* structure type
+- it is not defined in any public header. This means that we don't know what
+fields the structure has, or even how large it is. As a result, we cannot
+perform any operations on the structure itself, but we can work with *pointers*
+to the structure - which is exactly what ``dispatch_get_main_queue`` does.
 
-Even though ``struct dispatch_queue_s`` is opaque, we still need to define it in Python so that we can look up the ``_dispatch_main_q`` variable:
+Even though ``struct dispatch_queue_s`` is opaque, we still need to define it
+in Python so that we can look up the ``_dispatch_main_q`` variable:
 
 .. code-block:: python
 
@@ -268,19 +393,23 @@ Even though ``struct dispatch_queue_s`` is opaque, we still need to define it in
 
     _dispatch_main_q = struct_dispatch_queue_s.in_dll(libdispatch, "_dispatch_main_q")
 
-Now we need to look at the definition of the ``dispatch_queue_main_t`` type. This definition is not very obvious to find - it's actually this line in ``<dispatch/queue.h>``:
+Now we need to look at the definition of the ``dispatch_queue_main_t`` type.
+This definition is not very obvious to find - it's actually this line in
+``<dispatch/queue.h>``:
 
 .. code-block:: objc
 
     DISPATCH_DECL_SUBCLASS(dispatch_queue_main, dispatch_queue_serial);
 
-``DISPATCH_DECL_SUBCLASS`` is a macro from ``<dispatch/object.h>``, defined like this:
+``DISPATCH_DECL_SUBCLASS`` is a macro from ``<dispatch/object.h>``, defined
+like this:
 
 .. code-block:: objc
 
     #define DISPATCH_DECL_SUBCLASS(name, base) OS_OBJECT_DECL_SUBCLASS(name, base)
 
-It directly calls another macro, ``OS_OBJECT_DECL_SUBCLASS``, defined in ``<os/object.h>``:
+It directly calls another macro, ``OS_OBJECT_DECL_SUBCLASS``, defined in
+``<os/object.h>``:
 
 .. code-block:: objc
 
@@ -342,7 +471,8 @@ And substituted into our code:
     typedef NSObject<OS_dispatch_queue_main> \
         * OS_OBJC_INDEPENDENT_CLASS dispatch_queue_main_t;
 
-Finally we're left with the ``OS_OBJECT_INDEPENDENT_CLASS`` macro, which is a compiler attribute that we can ignore.
+Finally we're left with the ``OS_OBJECT_INDEPENDENT_CLASS`` macro, which is a
+compiler attribute that we can ignore.
 
 .. code-block:: objc
 
@@ -350,7 +480,14 @@ Finally we're left with the ``OS_OBJECT_INDEPENDENT_CLASS`` macro, which is a co
     @end
     typedef NSObject<OS_dispatch_queue_main> * dispatch_queue_main_t;
 
-Now we're done with macro expansion and can see what the code actually does - it defines an Objective-C protocol called ``OS_dispatch_queue_main`` and defines ``dispatch_queue_main_t`` as a pointer type to an object conforming to that protocol. For our purposes, most of these details don't matter - the important part is that ``dispatch_queue_main_t`` is actually an Objective-C object pointer type. Because Rubicon doesn't differentiate between object pointer types, we can replace ``dispatch_queue_main_t`` in our original function with the generic ``id`` type:
+Now we're done with macro expansion and can see what the code actually does -
+it defines an Objective-C protocol called ``OS_dispatch_queue_main`` and
+defines ``dispatch_queue_main_t`` as a pointer type to an object conforming to
+that protocol. For our purposes, most of these details don't matter - the
+important part is that ``dispatch_queue_main_t`` is actually an Objective-C
+object pointer type. Because Rubicon doesn't differentiate between object
+pointer types, we can replace ``dispatch_queue_main_t`` in our original
+function with the generic ``id`` type:
 
 .. code-block:: objc
 

--- a/docs/how-to/contribute-code.rst
+++ b/docs/how-to/contribute-code.rst
@@ -18,7 +18,7 @@ The recommended way of setting up your development environment for Rubicon is
 to clone the repository, create a virtual environment, and install the required
 dependencies:
 
-.. code-block:: sh
+.. code-block:: console
 
     $ git clone https://github.com/beeware/rubicon-objc.git
     $ cd rubicon-objc
@@ -31,7 +31,7 @@ simple issues and standardize code formatting. It does this by installing a git
 hook that automatically runs a series of code linters prior to finalizing any
 git commit. To enable pre-commit, run:
 
-.. code-block:: sh
+.. code-block:: console
 
     (venv) $ pre-commit install
     pre-commit installed at .git/hooks/pre-commit
@@ -40,7 +40,7 @@ When you commit any change, pre-commit will run automatically. If there are any
 issues found with the commit, this will cause your commit to fail. Where possible,
 pre-commit will make the changes needed to correct the problems it has found:
 
-.. code-block:: sh
+.. code-block:: console
 
     (venv) $ git add some/interesting_file.py
     (venv) $ git commit -m "Minor change"
@@ -68,7 +68,7 @@ pre-commit will make the changes needed to correct the problems it has found:
 You can then re-add any files that were modified as a result of the pre-commit checks,
 and re-commit the change.
 
-.. code-block:: sh
+.. code-block:: console
 
     (venv) $ git add some/interesting_file.py
     (venv) $ git commit -m "Minor change"
@@ -90,7 +90,7 @@ Rubicon uses `tox <https://tox.wiki/en/latest/>`__ to manage the
 testing process. To set up a testing environment and run the full test suite,
 run:
 
-.. code-block:: sh
+.. code-block:: console
 
     (venv) $ tox
 
@@ -99,15 +99,15 @@ version supported by Rubicon, as well as running some pre-commit checks of
 code style and validity. This can take a while, so if you want to speed up
 the process while developing, you can run the tests on one Python version only:
 
-.. code-block:: sh
+.. code-block:: console
 
     (venv) $ tox -e py
 
 Or, to run using a specific version of Python:
 
-.. code-block:: sh
+.. code-block:: console
 
-    (venv) $ tox -e py37
+    (venv) $ tox -e py310
 
 substituting the version number that you want to target. You can also specify
 one of the pre-commit checks `flake8`, `docs` or `package` to check code

--- a/docs/how-to/contribute-docs.rst
+++ b/docs/how-to/contribute-docs.rst
@@ -25,20 +25,20 @@ To build the documentation locally, :ref:`set up a development environment
 You'll also need to install the Enchant spell checking library.
 Enchant can be installed using `Homebrew <https://brew.sh>`__:
 
-.. code-block:: bash
+.. code-block:: console
 
   (venv) $ brew install enchant
 
 If you're on an M1 machine, you'll also need to manually set the location
 of the Enchant library:
 
-.. code-block:: bash
+.. code-block:: console
 
   (venv) $ export PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.2.dylib
 
 Once your development environment is set up, run:
 
-.. code-block:: bash
+.. code-block:: console
 
   (venv) $ tox -e docs
 
@@ -55,19 +55,19 @@ documentation:
 
   .. group-tab:: macOS
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ tox -e docs-lint
 
   .. group-tab:: Linux
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ tox -e docs-lint
 
   .. group-tab:: Windows
 
-    .. code-block:: powershell
+    .. code-block:: doscon
 
       C:\...>tox -e docs-lint
 
@@ -90,19 +90,19 @@ To force a rebuild for all of the documentation:
 
   .. group-tab:: macOS
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ tox -e docs-all
 
   .. group-tab:: Linux
 
-    .. code-block:: bash
+    .. code-block:: console
 
       (venv) $ tox -e docs-all
 
   .. group-tab:: Windows
 
-    .. code-block:: powershell
+    .. code-block:: doscon
 
       C:\...>tox -e docs-all
 

--- a/docs/how-to/get-started.rst
+++ b/docs/how-to/get-started.rst
@@ -2,7 +2,9 @@
 Getting Started with Rubicon
 ============================
 
-To use Rubicon, create a new virtual environment, and install it::
+To use Rubicon, create a new virtual environment, and install it:
+
+.. code-block:: console
 
     $ python3 -m venv venv
     $ source venv/bin/activate.sh

--- a/docs/how-to/internal/release.rst
+++ b/docs/how-to/internal/release.rst
@@ -8,36 +8,46 @@ to formally publish releases.
 This guide assumes that you have an ``upstream`` remote configured on your
 local clone of the Rubicon repository, pointing at the official repository. If
 all you have is a checkout of a personal fork of the Rubicon-ObjC repository,
-you can configure that checkout by running::
+you can configure that checkout by running:
 
-    $ git remote add upstream https://github.com/beeware/rubicon-objc.git
+.. code-block:: console
+
+  $ git remote add upstream https://github.com/beeware/rubicon-objc.git
 
 The procedure for cutting a new release is as follows:
 
-1. Check the contents of the upstream repository's main branch::
+#. Check the contents of the upstream repository's main branch:
 
-    $ git fetch upstream
-    $ git checkout --detach upstream/main
+   .. code-block:: console
+
+     $ git fetch upstream
+     $ git checkout --detach upstream/main
 
    Check that the HEAD of release now matches upstream/main.
 
-2. Ensure that the release notes are up to date. Run::
+#. Ensure that the release notes are up to date. Run:
 
-      $ tox -e towncrier -- --draft
+   .. code-block:: console
 
-   to review the release notes that will be included, and then::
+     $ tox -e towncrier -- --draft
 
-         $ tox -e towncrier
+   to review the release notes that will be included, and then:
+
+   .. code-block:: console
+
+     $ tox -e towncrier
 
    to generate the updated release notes.
 
-3. Tag the release, and push the tag upstream::
+#. Tag the release, and push the tag upstream:
 
-    $ git tag v1.2.3
-    $ git push upstream HEAD:main
-    $ git push upstream v1.2.3
+   .. code-block:: console
 
-4. Pushing the tag will start a workflow to create a draft release on GitHub.
+     $ git tag v1.2.3
+     $ git push upstream HEAD:main
+     $ git push upstream v1.2.3
+
+#. Pushing the tag will start a workflow to create a draft release on GitHub.
    You can `follow the progress of the workflow on GitHub
    <https://github.com/beeware/rubicon-objc/actions?query=workflow%3A%22Create+Release%22>`__;
    once the workflow completes, there should be a new `draft release
@@ -59,31 +69,33 @@ The procedure for cutting a new release is as follows:
       code change, delete the old tag, make the code change, and re-tag the
       release.
 
-5. Create a clean virtual environment, install the new release from Test PyPI, and
-   perform any pre-release testing that may be appropriate::
+#. Create a clean virtual environment, install the new release from Test PyPI, and
+   perform any pre-release testing that may be appropriate:
 
-    $ python3 -m venv testvenv
-    $ . ./testvenv/bin/activate
-    (testvenv) $ pip install --extra-index-url https://test.pypi.org/simple/ rubicon-objc==1.2.3
-    (testvenv) $ python -c "from rubicon.objc import __version__; print(__version__)"
-    1.2.3
-    (testvenv) $ ... any other manual checks you want to perform ...
+   .. code-block:: console
 
-6. Log into ReadTheDocs, visit the `Versions tab
+     $ python3 -m venv testvenv
+     $ . ./testvenv/bin/activate
+     (testvenv) $ pip install --extra-index-url https://test.pypi.org/simple/ rubicon-objc==1.2.3
+     (testvenv) $ python -c "from rubicon.objc import __version__; print(__version__)"
+     1.2.3
+     (testvenv) $ #... any other manual checks you want to perform ...
+
+#. Log into ReadTheDocs, visit the `Versions tab
    <https://readthedocs.org/projects/rubicon-objc/versions/>`__, and activate the
    new version. Ensure that the build completes; if there's a problem, you
    may need to correct the build configuration, roll back and re-tag the release.
 
-7. Edit the GitHub release to add release notes. You can use the text generated
+#. Edit the GitHub release to add release notes. You can use the text generated
    by Towncrier, but you'll need to update the format to Markdown, rather than
    ReST. If necessary, check the pre-release checkbox.
 
-8. Double check everything, then click Publish. This will trigger a
+#. Double check everything, then click Publish. This will trigger a
    `publication workflow on GitHub
    <https://github.com/beeware/rubicon-objc/actions?query=workflow%3A%22Upload+Python+Package%22>`__.
 
-7. Wait for the `package to appear on PyPI
-<https://pypi.org/project/rubicon-objc/>`__.
+#. Wait for the `package to appear on PyPI
+   <https://pypi.org/project/rubicon-objc/>`__.
 
 Congratulations, you've just published a release!
 

--- a/docs/how-to/protocols.rst
+++ b/docs/how-to/protocols.rst
@@ -96,12 +96,12 @@ Objective-C classes:
 There are two notable differences between creating classes and protocols:
 
 1. Protocols do not need to extend exactly one other protocol - they can also
-extend multiple protocols, or none at all. When not extending other protocols,
-as is the case here, we need to explicitly add ``metaclass=ObjCProtocol`` to
-the base class list, to tell Python that this is a protocol and not a regular
-Python class. When extending other protocols, Python detects this
-automatically.
+   extend multiple protocols, or none at all. When not extending other
+   protocols, as is the case here, we need to explicitly add
+   ``metaclass=ObjCProtocol`` to the base class list, to tell Python that this
+   is a protocol and not a regular Python class. When extending other
+   protocols, Python detects this automatically.
 2. Protocol methods do not have a body. Python has no dedicated syntax for
-functions without a body, so we put ``...`` in the body instead. (You could
-technically put code in the body, but this would be misleading and is not
-recommended.)
+   functions without a body, so we put ``...`` in the body instead. (You could
+   technically put code in the body, but this would be misleading and is not
+   recommended.)

--- a/docs/how-to/type-mapping.rst
+++ b/docs/how-to/type-mapping.rst
@@ -352,20 +352,43 @@ Mapping methods like ``keys`` and ``values`` are also supported:
 Manual conversions
 ------------------
 
-If necessary, you can also manually call Rubicon's type conversion functions, to convert objects between Python and Objective-C when Rubicon doesn't do so automatically.
+If necessary, you can also manually call Rubicon's type conversion functions,
+to convert objects between Python and Objective-C when Rubicon doesn't do so
+automatically.
 
 Converting from Python to Objective-C
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The function :func:`~rubicon.objc.api.ns_from_py` (also available as :func:`~rubicon.objc.api.at` for short) can convert most standard Python objects to Foundation equivalents. For a full list of possible conversions, see the reference documentation for :func:`~rubicon.objc.api.ns_from_py`.
+The function :func:`~rubicon.objc.api.ns_from_py` (also available as
+:func:`~rubicon.objc.api.at` for short) can convert most standard Python
+objects to Foundation equivalents. For a full list of possible conversions, see
+the reference documentation for :func:`~rubicon.objc.api.ns_from_py`.
 
-These conversions are performed automatically when a Python object is passed into an Objective-C method parameter that expects an object - in that case you do not need to call :func:`~rubicon.objc.api.ns_from_py` manually (see :ref:`argument_conversion`).
+These conversions are performed automatically when a Python object is passed
+into an Objective-C method parameter that expects an object - in that case you
+do not need to call :func:`~rubicon.objc.api.ns_from_py` manually (see
+:ref:`argument_conversion`).
 
 Converting from Objective-C to Python
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The function :func:`~rubicon.objc.api.py_from_ns` can convert many common Foundation objects to Python equivalents. For a full list of possible conversions, see the reference documentation for :func:`~rubicon.objc.api.py_from_ns`.
+The function :func:`~rubicon.objc.api.py_from_ns` can convert many common
+Foundation objects to Python equivalents. For a full list of possible
+conversions, see the reference documentation for
+:func:`~rubicon.objc.api.py_from_ns`.
 
-These conversions are not performed automatically by Rubicon. For example, if an Objective-C method returns an ``NSString``, Rubicon will return it as an :class:`~rubicon.objc.api.ObjCInstance` (with some additional Python methods - see :ref:`python_style_apis_for_objc`). Using :func:`~rubicon.objc.api.py_from_ns`, you can convert the ``NSString`` to a real Python ``str``.
+These conversions are not performed automatically by Rubicon. For example, if
+an Objective-C method returns an ``NSString``, Rubicon will return it as an
+:class:`~rubicon.objc.api.ObjCInstance` (with some additional Python methods -
+see :ref:`python_style_apis_for_objc`). Using
+:func:`~rubicon.objc.api.py_from_ns`, you can convert the ``NSString`` to a
+real Python :class:`str`.
 
-When converting collections, such as ``NSArray`` or ``NSDictionary``, :func:`~rubicon.objc.api.py_from_ns` will convert them recursively to a pure Python object. For example, if ``nsarray`` is an ``NSArray`` containing ``NSString``\s, ``py_from_ns(nsarray)`` will return a ``list`` of ``str``\s. In most cases, that is the desired behavior, but you can also avoid this recursive conversion by passing the Foundation collection into a Python collection constructor: for example ``list(nsarray)`` will return a ``list`` of ``NSString``\s.
+When converting collections, such as ``NSArray`` or ``NSDictionary``,
+:func:`~rubicon.objc.api.py_from_ns` will convert them recursively to a pure
+Python object. For example, if ``nsarray`` is an ``NSArray`` containing
+``NSString``\s, ``py_from_ns(nsarray)`` will return a :class:`list` of
+:class:`str`\s. In most cases, that is the desired behavior, but you can also
+avoid this recursive conversion by passing the Foundation collection into a
+Python collection constructor: for example ``list(nsarray)`` will return a
+:class:`list` of ``NSString``\s.

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -13,4 +13,6 @@ Reference
 
 This is the technical reference for public APIs provided by Rubicon.
 
-Note that the :mod:`rubicon.objc` package also contains other submodules not documented here. These are for internal use only and not part of the public API; they may change at any time without notice.
+Note that the :mod:`rubicon.objc` package also contains other submodules not
+documented here. These are for internal use only and not part of the public
+API; they may change at any time without notice.

--- a/docs/reference/rubicon-objc-api.rst
+++ b/docs/reference/rubicon-objc-api.rst
@@ -4,9 +4,12 @@
 
 .. module:: rubicon.objc.api
 
-This module contains Rubicon's main high-level APIs, which allow easy interaction with Objective-C classes and objects using Pythonic syntax.
+This module contains Rubicon's main high-level APIs, which allow easy
+interaction with Objective-C classes and objects using Pythonic syntax.
 
-Nearly all attributes of this module are also available on the main :mod:`rubicon.objc` module, and if possible that module should be used instead of importing :mod:`rubicon.objc.api` directly.
+Nearly all attributes of this module are also available on the main
+:mod:`rubicon.objc` module, and if possible that module should be used instead
+of importing :mod:`rubicon.objc.api` directly.
 
 Objective-C objects
 -------------------
@@ -17,7 +20,9 @@ Objective-C objects
         ptr
         _as_parameter_
 
-        The wrapped object pointer as an :class:`~rubicon.objc.runtime.objc_id`. This attribute is also available as ``_as_parameter_`` to allow :class:`ObjCInstance`\s to be passed into :mod:`ctypes` functions.
+        The wrapped object pointer as an :class:`~rubicon.objc.runtime.objc_id`.
+        This attribute is also available as ``_as_parameter_`` to allow
+        :class:`ObjCInstance`\s to be passed into :mod:`ctypes` functions.
 
     .. autoattribute:: objc_class
     .. automethod:: __str__
@@ -48,66 +53,103 @@ Objective-C classes
 Standard Objective-C and Foundation classes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The following classes from the `Objective-C runtime <https://developer.apple.com/documentation/objectivec?language=objc>`__ and the `Foundation <https://developer.apple.com/documentation/foundation?language=objc>`__ framework are provided as :class:`ObjCClass`\es for convenience. (Other classes not listed here can be looked up by passing a class name to the :class:`ObjCClass` constructor.)
+The following classes from the `Objective-C runtime
+<https://developer.apple.com/documentation/objectivec?language=objc>`__ and the
+`Foundation <https://developer.apple.com/documentation/foundation?language=objc>`__
+framework are provided as :class:`ObjCClass`\es for convenience. (Other classes
+not listed here can be looked up by passing a class name to the
+:class:`ObjCClass` constructor.)
 
 .. note::
 
-    None of the following classes have a usable Python-style constructor - for example, you *cannot* call ``NSString("hello")`` to create an Objective-C string from a Python string. To create instances of these classes, you should use :func:`ns_from_py` (also called :func:`at`): ``ns_from_py("hello")`` returns a :class:`NSString` instance with the value ``hello``.
+    None of the following classes have a usable Python-style constructor - for
+    example, you *cannot* call ``NSString("hello")`` to create an Objective-C
+    string from a Python string. To create instances of these classes, you
+    should use :func:`ns_from_py` (also called :func:`at`):
+    ``ns_from_py("hello")`` returns a :class:`NSString` instance with the value
+    ``hello``.
 
 .. class::
     NSObject
 
-    The `NSObject <https://developer.apple.com/documentation/objectivec/nsobject?language=objc>`__ class from ``<objc/NSObject.h>``.
+    The `NSObject
+    <https://developer.apple.com/documentation/objectivec/nsobject?language=objc>`__
+    class from ``<objc/NSObject.h>``.
 
     .. note::
 
-        See the :class:`ObjCInstance` documentation for a list of operations that Rubicon supports on all objects.
+        See the :class:`ObjCInstance` documentation for a list of operations
+        that Rubicon supports on all objects.
 
     .. attribute::
         debugDescription
         description
 
-        These Objective-C properties have been declared using :meth:`ObjCClass.declare_property` and can always be accessed using attribute syntax.
+        These Objective-C properties have been declared using
+        :meth:`ObjCClass.declare_property` and can always be accessed using
+        attribute syntax.
 
 .. class::
     Protocol
 
-    The `Protocol <https://developer.apple.com/documentation/objectivec/protocol?language=objc>`__ class from ``<objc/Protocol.h>``.
+    The `Protocol
+    <https://developer.apple.com/documentation/objectivec/protocol?language=objc>`__
+    class from ``<objc/Protocol.h>``.
 
     .. note::
 
-        This class has no (non-deprecated) Objective-C methods; protocol objects can only be manipulated using Objective-C runtime functions. Rubicon automatically wraps all :class:`Protocol` objects using :class:`ObjCProtocol`, which provides an easier interface for working with protocols.
+        This class has no (non-deprecated) Objective-C methods; protocol
+        objects can only be manipulated using Objective-C runtime functions.
+        Rubicon automatically wraps all :class:`Protocol` objects using
+        :class:`ObjCProtocol`, which provides an easier interface for working
+        with protocols.
 
 .. class::
     NSNumber
 
-    The `NSNumber <https://developer.apple.com/documentation/foundation/nsnumber?language=objc>`__ class from ``<Foundation/NSValue.h>``.
+    The `NSNumber
+    <https://developer.apple.com/documentation/foundation/nsnumber?language=objc>`__
+    class from ``<Foundation/NSValue.h>``.
 
     .. note::
 
-        This class can be converted to and from standard Python primitives (``bool``, ``int``, ``float``) using :func:`py_from_ns` and :func:`ns_from_py`.
+        This class can be converted to and from standard Python primitives
+        (``bool``, ``int``, ``float``) using :func:`py_from_ns` and
+        :func:`ns_from_py`.
 
 .. class::
     NSDecimalNumber
 
-    The `NSDecimalNumber <https://developer.apple.com/documentation/foundation/nsdecimalnumber?language=objc>`__ class from ``<Foundation/NSDecimalNumber.h>``.
+    The `NSDecimalNumber
+    <https://developer.apple.com/documentation/foundation/nsdecimalnumber?language=objc>`__
+    class from ``<Foundation/NSDecimalNumber.h>``.
 
     .. note::
 
-        This class can be converted to and from Python ``decimal.Decimal`` using :func:`py_from_ns` and :func:`ns_from_py`.
+        This class can be converted to and from Python ``decimal.Decimal``
+        using :func:`py_from_ns` and :func:`ns_from_py`.
 
 .. class::
     NSString
 
-    The `NSString <https://developer.apple.com/documentation/foundation/nsstring?language=objc>`__ class from ``<Foundation/NSString.h>``.
+    The `NSString
+    <https://developer.apple.com/documentation/foundation/nsstring?language=objc>`__
+    class from ``<Foundation/NSString.h>``.
 
     This class also supports all methods that :class:`str` does.
 
     .. note::
 
-        This class can be converted to and from Python ``str`` using :func:`py_from_ns` and :func:`ns_from_py`. You can also call ``str(nsstring)`` to convert a ``NSString`` to ``str``.
+        This class can be converted to and from Python :class:`str` using
+        :func:`py_from_ns` and :func:`ns_from_py`. You can also call
+        ``str(nsstring)`` to convert a ``NSString`` to :class:`str`.
 
-        :class:`NSString` objects consist of UTF-16 code units, unlike :class:`str`, which consists of Unicode code points. All :class:`NSString` indices and iteration are based on UTF-16, even when using the Python-style operations/methods. If indexing or iteration based on code points is required, convert the :class:`NSString` to :class:`str` first.
+        :class:`NSString` objects consist of UTF-16 code units, unlike
+        :class:`str`, which consists of Unicode code points. All
+        :class:`NSString` indices and iteration are based on UTF-16, even when
+        using the Python-style operations/methods. If indexing or iteration
+        based on code points is required, convert the :class:`NSString` to
+        :class:`str` first.
 
     .. method:: __str__()
 
@@ -116,29 +158,43 @@ The following classes from the `Objective-C runtime <https://developer.apple.com
     .. attribute::
         UTF8String
 
-        This Objective-C property has been declared using :meth:`ObjCClass.declare_property` and can always be accessed using attribute syntax.
+        This Objective-C property has been declared using
+        :meth:`ObjCClass.declare_property` and can always be accessed using
+        attribute syntax.
 
 .. class::
     NSData
 
-    The `NSData <https://developer.apple.com/documentation/foundation/nsdata?language=objc>`__ class from ``<Foundation/NSData.h>``.
+    The `NSData
+    <https://developer.apple.com/documentation/foundation/nsdata?language=objc>`__
+    class from ``<Foundation/NSData.h>``.
 
     .. note::
 
-        This class can be converted to and from Python ``bytes`` using :func:`py_from_ns` and :func:`ns_from_py`.
+        This class can be converted to and from Python :class:`bytes` using
+        :func:`py_from_ns` and :func:`ns_from_py`.
 
 .. class::
     NSArray
 
-    The `NSArray <https://developer.apple.com/documentation/foundation/nsarray?language=objc>`__ class from ``<Foundation/NSArray.h>``.
+    The `NSArray
+    <https://developer.apple.com/documentation/foundation/nsarray?language=objc>`__
+    class from ``<Foundation/NSArray.h>``.
 
     .. note::
 
-        This class can be converted to and from Python ``list`` using :func:`py_from_ns` and :func:`ns_from_py`.
+        This class can be converted to and from Python :class:`list` using
+        :func:`py_from_ns` and :func:`ns_from_py`.
 
-        ``py_from_ns(nsarray)`` will recursively convert ``nsarray``'s elements to Python objects, where possible. To avoid this recursive conversion, use ``list(nsarray)`` instead.
+        ``py_from_ns(nsarray)`` will recursively convert ``nsarray``'s elements
+        to Python objects, where possible. To avoid this recursive conversion,
+        use ``list(nsarray)`` instead.
 
-        ``ns_from_py(pylist)`` will recursively convert ``pylist``'s elements to Objective-C. As there is no way to store Python object references as Objective-C objects yet, this recursive conversion cannot be avoided. If any of ``pylist``'s elements cannot be converted to Objective-C, an error is raised.
+        ``ns_from_py(pylist)`` will recursively convert ``pylist``'s elements
+        to Objective-C. As there is no way to store Python object references
+        as Objective-C objects yet, this recursive conversion cannot be
+        avoided. If any of ``pylist``'s elements cannot be converted to
+        Objective-C, an error is raised.
 
     .. method::
         __getitem__(index)
@@ -156,11 +212,14 @@ The following classes from the `Objective-C runtime <https://developer.apple.com
 .. class::
     NSMutableArray
 
-    The `NSMutableArray <https://developer.apple.com/documentation/foundation/nsmutablearray?language=objc>`__ class from ``<Foundation/NSArray.h>``.
+    The `NSMutableArray
+    <https://developer.apple.com/documentation/foundation/nsmutablearray?language=objc>`__
+    class from ``<Foundation/NSArray.h>``.
 
     .. note::
 
-        This class can be converted to and from Python exactly like its superclass ``NSArray``.
+        This class can be converted to and from Python exactly like its
+        superclass ``NSArray``.
 
     .. method::
         __setitem__(index, value)
@@ -178,15 +237,29 @@ The following classes from the `Objective-C runtime <https://developer.apple.com
 .. class::
     NSDictionary
 
-    The `NSDictionary <https://developer.apple.com/documentation/foundation/nsdictionary?language=objc>`__ class from ``<Foundation/NSDictionary.h>``.
+    The `NSDictionary
+    <https://developer.apple.com/documentation/foundation/nsdictionary?language=objc>`__
+    class from ``<Foundation/NSDictionary.h>``.
 
     .. note::
 
-        This class can be converted to and from Python ``dict`` using :func:`py_from_ns` and :func:`ns_from_py`.
+        This class can be converted to and from Python :class:`dict` using
+        :func:`py_from_ns` and :func:`ns_from_py`.
 
-        ``py_from_ns(nsdict)`` will recursively convert ``nsdict``'s keys and values to Python objects, where possible. To avoid the recursive conversion of the values, use ``{py_from_ns(k): v for k, v in nsdict.items()}``. The conversion of the keys cannot be avoided, because Python ``dict`` keys need to be hashable, which :class:`ObjCInstance` is not. If any of the keys convert to a Python object that is not hashable, an error is raised (regardless of which conversion method you use).
+        ``py_from_ns(nsdict)`` will recursively convert ``nsdict``'s keys and
+        values to Python objects, where possible. To avoid the recursive
+        conversion of the values, use ``{py_from_ns(k): v for k, v in
+        nsdict.items()}``. The conversion of the keys cannot be avoided,
+        because Python :class:`dict` keys need to be hashable, which
+        :class:`ObjCInstance` is not. If any of the keys convert to a Python
+        object that is not hashable, an error is raised (regardless of which
+        conversion method you use).
 
-        ``ns_from_py(pydict)`` will recursively convert ``pydict``'s keys and values to Objective-C. As there is no way to store Python object references as Objective-C objects yet, this recursive conversion cannot be avoided. If any of ``pydict``'s keys or values cannot be converted to Objective-C, an error is raised.
+        ``ns_from_py(pydict)`` will recursively convert ``pydict``'s keys and
+        values to Objective-C. As there is no way to store Python object
+        references as Objective-C objects yet, this recursive conversion cannot
+        be avoided. If any of ``pydict``'s keys or values cannot be converted
+        to Objective-C, an error is raised.
 
     .. method::
         __getitem__(key)
@@ -205,20 +278,33 @@ The following classes from the `Objective-C runtime <https://developer.apple.com
 
         .. note::
 
-            Unlike most Python mappings, :class:`NSDictionary`'s :attr:`keys`, :attr:`values`, and :attr:`items` methods don't return dynamic views of the dictionary's keys, values, and items.
+            Unlike most Python mappings, :class:`NSDictionary`'s :attr:`keys`,
+            :attr:`values`, and :attr:`items` methods don't return dynamic
+            views of the dictionary's keys, values, and items.
 
-            :attr:`keys` and :attr:`values` return lists that are created each time the methods are called, which can have an effect on performance and memory usage for large dictionaries. To avoid this, you can cache the return values of :attr:`keys` and :attr:`values`, or convert the :class:`NSDictionary` to a Python :class:`dict` beforehand.
+            :attr:`keys` and :attr:`values` return lists that are created each
+            time the methods are called, which can have an effect on
+            performance and memory usage for large dictionaries. To avoid this,
+            you can cache the return values of :attr:`keys` and :attr:`values`,
+            or convert the :class:`NSDictionary` to a Python :class:`dict`
+            beforehand.
 
-            :attr:`items` is currently implemented as a generator, meaning that it returns a single-use iterator. If you need to iterate over :attr:`items` more than once or perform other operations on it, you should convert it to a Python :class:`set` or :class:`list` first.
+            :attr:`items` is currently implemented as a generator, meaning that
+            it returns a single-use iterator. If you need to iterate over
+            :attr:`items` more than once or perform other operations on it, you
+            should convert it to a Python :class:`set` or :class:`list` first.
 
 .. class::
     NSMutableDictionary
 
-    The `NSMutableDictionary <https://developer.apple.com/documentation/foundation/nsmutabledictionary?language=objc>`__ class from ``<Foundation/NSDictionary.h>``.
+    The `NSMutableDictionary
+    <https://developer.apple.com/documentation/foundation/nsmutabledictionary?language=objc>`__
+    class from ``<Foundation/NSDictionary.h>``.
 
     .. note::
 
-        This class can be converted to and from Python exactly like its superclass ``NSDictionary``.
+        This class can be converted to and from Python exactly like its
+        superclass ``NSDictionary``.
 
     .. method::
         __setitem__(key, value)
@@ -244,11 +330,20 @@ Objective-C protocols
 Standard Objective-C and Foundation protocols
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The following protocols from the `Objective-C runtime <https://developer.apple.com/documentation/objectivec?language=objc>`__ and the `Foundation <https://developer.apple.com/documentation/foundation?language=objc>`__ framework are provided as :class:`ObjCProtocol`\s for convenience. (Other protocols not listed here can be looked up by passing a protocol name to the :class:`ObjCProtocol` constructor.)
+The following protocols from the `Objective-C runtime
+<https://developer.apple.com/documentation/objectivec?language=objc>`__ and the
+`Foundation <https://developer.apple.com/documentation/foundation?language=objc>`__
+framework are provided as :class:`ObjCProtocol`\s for convenience. (Other
+protocols not listed here can be looked up by passing a protocol name to the
+:class:`ObjCProtocol` constructor.)
 
 .. data:: NSObjectProtocol
 
-    The `NSObject <https://developer.apple.com/documentation/objectivec/1418956-nsobject?language=objc>`__ protocol from ``<objc/NSObject.h>``. The protocol is exported as :class:`NSObjectProtocol` in Python because it would otherwise clash with the :class:`NSObject` class.
+    The `NSObject
+    <https://developer.apple.com/documentation/objectivec/1418956-nsobject?language=objc>`__
+    protocol from ``<objc/NSObject.h>``. The protocol is exported as
+    :class:`NSObjectProtocol` in Python because it would otherwise clash with
+    the :class:`NSObject` class.
 
 Converting objects between Objective-C and Python
 -------------------------------------------------
@@ -265,14 +360,18 @@ Converting objects between Objective-C and Python
 Creating custom Objective-C classes and protocols
 -------------------------------------------------
 
-Custom Objective-C classes are defined using Python ``class`` syntax, by subclassing an existing :class:`ObjCClass` object:
+Custom Objective-C classes are defined using Python ``class`` syntax, by
+subclassing an existing :class:`ObjCClass` object:
 
 .. code-block:: python
 
     class MySubclass(NSObject):
         # method, property, etc. definitions go here
 
-A custom Objective-C class can only have a single superclass, since Objective-C does not support multiple inheritance. However, the class can conform to any number of protocols, which are specified by adding the ``protocols`` keyword argument to the base class list:
+A custom Objective-C class can only have a single superclass, since Objective-C
+does not support multiple inheritance. However, the class can conform to any
+number of protocols, which are specified by adding the ``protocols`` keyword
+argument to the base class list:
 
 .. code-block:: python
 
@@ -281,18 +380,31 @@ A custom Objective-C class can only have a single superclass, since Objective-C 
 
 .. note::
 
-    Rubicon requires specifying a superclass when defining a custom Objective-C class. If you don't need to extend any specific class, use :class:`NSObject` as the superclass.
+    Rubicon requires specifying a superclass when defining a custom Objective-C
+    class. If you don't need to extend any specific class, use
+    :class:`NSObject` as the superclass.
 
-    Although Objective-C technically allows defining classes without a base class (so-called *root classes*), this is almost never the desired behavior (attempting to do so `causes a compiler error by default <https://developer.apple.com/documentation/objectivec/objc_root_class>`_). In practice, this feature is only used in the definitions of core Objective-C classes like :class:`NSObject`. Because of this, Rubicon does not support defining Objective-C root classes.
+    Although Objective-C technically allows defining classes without a base
+    class (so-called *root classes*), this is almost never the desired behavior
+    (attempting to do so `causes a compiler error by default
+    <https://developer.apple.com/documentation/objectivec/objc_root_class>`_).
+    In practice, this feature is only used in the definitions of core
+    Objective-C classes like :class:`NSObject`. Because of this, Rubicon does
+    not support defining Objective-C root classes.
 
-Similar syntax is used to define custom Objective-C protocols. Unlike classes, protocols can extend multiple other protocols:
+Similar syntax is used to define custom Objective-C protocols. Unlike classes,
+protocols can extend multiple other protocols:
 
 .. code-block:: python
 
     class MyProtocol(NSCopying, NSMutableCopying):
         # method, property, etc. definitions go here
 
-A custom protocol might not need to extend any other protocol at all. In this case, we need to explicitly tell Python to define an :class:`ObjCProtocol`. Normally Python detects the metaclass automatically by examining the base classes, but in this case there are none, so we need to specify the metaclass manually.
+A custom protocol might not need to extend any other protocol at all. In this
+case, we need to explicitly tell Python to define an :class:`ObjCProtocol`.
+Normally Python detects the metaclass automatically by examining the base
+classes, but in this case there are none, so we need to specify the metaclass
+manually.
 
 .. code-block:: python
 
@@ -308,26 +420,54 @@ Defining methods
 Method naming
 """""""""""""
 
-The name of a Python-defined Objective-C method is same as the Python method's name, but with all underscores (``_``) replaced with colons (``:``) --- for example, ``initWithWidth_height_`` becomes ``initWithWidth:height:``.
+The name of a Python-defined Objective-C method is same as the Python method's
+name, but with all underscores (``_``) replaced with colons (``:``) --- for
+example, ``initWithWidth_height_`` becomes ``initWithWidth:height:``.
 
 .. warning::
 
-    The Objective-C *language* imposes certain requirements on the usage of colons in method names: a method's name must contain exactly as many colons as the method has arguments (excluding the implicit ``self`` and ``_cmd`` parameters), and the name of a method with arguments must end with a colon. For example, a method called ``init`` takes no arguments, ``initWithSize:`` takes a single argument, ``initWithWidth:height:`` takes two, etc. ``initWithSize:spam`` is an invalid method name.
+    The Objective-C *language* imposes certain requirements on the usage of
+    colons in method names: a method's name must contain exactly as many colons
+    as the method has arguments (excluding the implicit ``self`` and ``_cmd``
+    parameters), and the name of a method with arguments must end with a colon.
+    For example, a method called ``init`` takes no arguments, ``initWithSize:``
+    takes a single argument, ``initWithWidth:height:`` takes two, etc.
+    ``initWithSize:spam`` is an invalid method name.
 
-    These requirements are not enforced by the Objective-C *runtime*, but methods that do not follow them cannot easily be used from regular Objective-C code.
+    These requirements are not enforced by the Objective-C *runtime*, but
+    methods that do not follow them cannot easily be used from regular
+    Objective-C code.
 
-    In addition, although the Objective-C language allows method names with multiple consecutive colons or a colon at the start of the name, such names are considered bad style and never used in practice. For example, ``spam::``, ``:ham:``, and ``:`` are unusual, but valid method names.
+    In addition, although the Objective-C language allows method names with
+    multiple consecutive colons or a colon at the start of the name, such names
+    are considered bad style and never used in practice. For example,
+    ``spam::``, ``:ham:``, and ``:`` are unusual, but valid method names.
 
-    Future versions of Rubicon may warn about or disallow such nonstandard method names.
+    Future versions of Rubicon may warn about or disallow such nonstandard
+    method names.
 
 Parameter and return types
 """"""""""""""""""""""""""
 
-The argument and return types of a Python-created Objective-C method are determined based on the Python method's type annotations. The annotations may contain any :mod:`ctypes` type, as well as any of the Python types accepted by :func:`~rubicon.objc.types.ctype_for_type`. If a parameter or the return type is not specified, it defaults to :class:`ObjCInstance`. The ``self`` parameter is special-cased --- its type is always :class:`ObjCInstance`, even if annotated otherwise. To annotate a method as returning ``void``, set its return type to ``None``.
+The argument and return types of a Python-created Objective-C method are
+determined based on the Python method's type annotations. The annotations may
+contain any :mod:`ctypes` type, as well as any of the Python types accepted by
+:func:`~rubicon.objc.types.ctype_for_type`. If a parameter or the return type
+is not specified, it defaults to :class:`ObjCInstance`. The ``self`` parameter
+is special-cased --- its type is always :class:`ObjCInstance`, even if
+annotated otherwise. To annotate a method as returning ``void``, set its return
+type to :class:`None`.
 
-Before being passed to the Python method, any object parameters (:class:`~rubicon.objc.runtime.objc_id`) are automatically converted to :class:`ObjCInstance`. If the method returns an Objective-C object, it is converted using :func:`ns_from_py` before being returned to Objective-C. These automatic conversions can be disabled by using :func:`objc_rawmethod` instead of :func:`objc_method`.
+Before being passed to the Python method, any object parameters
+(:class:`~rubicon.objc.runtime.objc_id`) are automatically converted to
+:class:`ObjCInstance`. If the method returns an Objective-C object, it is
+converted using :func:`ns_from_py` before being returned to Objective-C. These
+automatic conversions can be disabled by using :func:`objc_rawmethod` instead
+of :func:`objc_method`.
 
-The implicit ``_cmd`` parameter is not passed to the Python method, as it is normally redundant and not needed. If needed, the ``_cmd`` parameter can be accessed by using :func:`objc_rawmethod` instead of :func:`objc_method`.
+The implicit ``_cmd`` parameter is not passed to the Python method, as it is
+normally redundant and not needed. If needed, the ``_cmd`` parameter can be
+accessed by using :func:`objc_rawmethod` instead of :func:`objc_method`.
 
 .. autofunction:: objc_rawmethod
 
@@ -344,19 +484,27 @@ Defining properties and ``ivars``
 Objective-C blocks
 ------------------
 
-Blocks are the Objective-C equivalent of function objects, so Rubicon provides ways to call Objective-C blocks from Python and to pass Python callables to Objective-C as blocks.
+Blocks are the Objective-C equivalent of function objects, so Rubicon provides
+ways to call Objective-C blocks from Python and to pass Python callables to
+Objective-C as blocks.
 
 Automatic conversion
 ^^^^^^^^^^^^^^^^^^^^
 
-If an Objective-C method returns a block (according to its type encoding), Rubicon will convert the return value to a special :class:`ObjCInstance` that can be called in Python:
+If an Objective-C method returns a block (according to its type encoding),
+Rubicon will convert the return value to a special :class:`ObjCInstance` that
+can be called in Python:
 
 .. code-block:: python
 
     block = an_objc_instance.methodReturningABlock()
     res = block(arg, ...)
 
-Similarly, if an Objective-C method has a parameter that expects a block, you can pass in a Python callable object, and it will be converted to an Objective-C block. In this case, the callable object needs to have parameter and return type annotations, so that Rubicon can expose this type information to the Objective-C runtime:
+Similarly, if an Objective-C method has a parameter that expects a block, you
+can pass in a Python callable object, and it will be converted to an
+Objective-C block. In this case, the callable object needs to have parameter
+and return type annotations, so that Rubicon can expose this type information
+to the Objective-C runtime:
 
 .. code-block:: python
 
@@ -365,7 +513,10 @@ Similarly, if an Objective-C method has a parameter that expects a block, you ca
 
     an_objc_instance.doSomethingWithResultHandler(result_handler)
 
-If you are writing a custom Objective-C method (see :ref:`custom-classes-and-protocols`), you can annotate parameter or return types using :class:`~rubicon.objc.runtime.objc_block` so that Rubicon converts them appropriately:
+If you are writing a custom Objective-C method (see
+:ref:`custom-classes-and-protocols`), you can annotate parameter or return
+types using :class:`~rubicon.objc.runtime.objc_block` so that Rubicon converts
+them appropriately:
 
 .. code-block:: python
 
@@ -383,14 +534,23 @@ If you are writing a custom Objective-C method (see :ref:`custom-classes-and-pro
 
 .. note::
 
-    These automatic conversions are mostly equivalent to the manual conversions described in the next section. There are internal technical differences between automatic and manual conversions, but they are not noticeable to most users.
+    These automatic conversions are mostly equivalent to the manual conversions
+    described in the next section. There are internal technical differences
+    between automatic and manual conversions, but they are not noticeable to
+    most users.
 
-    The internals of automatic conversion and :class:`~rubicon.objc.runtime.objc_block` handling may change in the future, so if you need more control over the block conversion process, you should use the manual conversions described in the next section.
+    The internals of automatic conversion and
+    :class:`~rubicon.objc.runtime.objc_block` handling may change in the
+    future, so if you need more control over the block conversion process, you
+    should use the manual conversions described in the next section.
 
 Manual conversion
 ^^^^^^^^^^^^^^^^^
 
-These classes are used to manually convert blocks to Python callables and vice versa. You may need to use them to perform these conversions outside of Objective-C method calls, or if you need more control over the block's type signature.
+These classes are used to manually convert blocks to Python callables and vice
+versa. You may need to use them to perform these conversions outside of
+Objective-C method calls, or if you need more control over the block's type
+signature.
 
 .. autoclass:: ObjCBlock(pointer, [return_type, *arg_types])
 
@@ -401,7 +561,11 @@ These classes are used to manually convert blocks to Python callables and vice v
 Defining custom subclasses of :class:`ObjCInstance`
 ---------------------------------------------------
 
-The following functions can be used to register custom subclasses of :class:`ObjCInstance` to be used when wrapping instances of a certain Objective-C class. This mechanism is for example used by Rubicon to provide Python-style operators and methods on standard Foundation classes, such as :class:`NSString` and :class:`NSDictionary`.
+The following functions can be used to register custom subclasses of
+:class:`ObjCInstance` to be used when wrapping instances of a certain
+Objective-C class. This mechanism is for example used by Rubicon to provide
+Python-style operators and methods on standard Foundation classes, such as
+:class:`NSString` and :class:`NSDictionary`.
 
 .. autofunction:: register_type_for_objcclass
 .. autofunction:: for_objcclass

--- a/docs/reference/rubicon-objc-eventloop.rst
+++ b/docs/reference/rubicon-objc-eventloop.rst
@@ -6,7 +6,8 @@
 
 .. note::
 
-    The documentation for this module is incomplete. You can help by :doc:`contributing to the documentation <../how-to/contribute-docs>`.
+    The documentation for this module is incomplete. You can help by
+    :doc:`contributing to the documentation <../how-to/contribute-docs>`.
 
 .. autoclass:: EventLoopPolicy
 

--- a/docs/reference/rubicon-objc-runtime.rst
+++ b/docs/reference/rubicon-objc-runtime.rst
@@ -4,16 +4,20 @@
 
 .. module:: rubicon.objc.runtime
 
-This module contains types, functions, and C libraries used for low-level access to the Objective-C runtime.
+This module contains types, functions, and C libraries used for low-level
+access to the Objective-C runtime.
 
-In most cases there is no need to use this module directly --- the :mod:`rubicon.objc.api` module provides the same functionality through a high-level interface.
+In most cases there is no need to use this module directly --- the
+:mod:`rubicon.objc.api` module provides the same functionality through a
+high-level interface.
 
 .. _predefined-c-libraries:
 
 C libraries
 -----------
 
-Some commonly used C libraries are provided as :class:`~ctypes.CDLL`\s. Other libraries can be loaded using the :func:`load_library` function.
+Some commonly used C libraries are provided as :class:`~ctypes.CDLL`\s. Other
+libraries can be loaded using the :func:`load_library` function.
 
 .. data:: libc
     :annotation: = load_library('c')
@@ -101,7 +105,8 @@ Some commonly used C libraries are provided as :class:`~ctypes.CDLL`\s. Other li
 .. data:: Foundation
     :annotation: = load_library('Foundation')
 
-    The `Foundation <https://developer.apple.com/documentation/foundation>`__ framework.
+    The `Foundation <https://developer.apple.com/documentation/foundation>`__
+    framework.
 
 .. autofunction:: load_library
 
@@ -149,18 +154,24 @@ These are various types used by the Objective-C runtime functions.
 
     .. attribute:: super_class
 
-        The class in which to start searching for method implementations, as a :class:`Class`.
+        The class in which to start searching for method implementations, as a
+        :class:`Class`.
 
 Objective-C runtime utility functions
 -------------------------------------
 
-These utility functions provide easier access from Python to certain parts of the Objective-C runtime.
+These utility functions provide easier access from Python to certain parts of
+the Objective-C runtime.
 
 .. function:: object_isClass(obj)
 
     Return whether the given Objective-C object is a class (or a metaclass).
 
-    This is equivalent to the :data:`libobjc` function `object_isClass <https://developer.apple.com/documentation/objectivec/1418659-object_isclass?language=objc>`__ from ``<objc/runtime.h>``, which is only available since OS X 10.10 and iOS 8. This module-level function is provided to support older systems --- it uses the :data:`libobjc` function if available, and otherwise emulates it.
+    This is equivalent to the :data:`libobjc` function `object_isClass
+    <https://developer.apple.com/documentation/objectivec/1418659-object_isclass?language=objc>`__
+    from ``<objc/runtime.h>``, which is only available since OS X 10.10 and iOS
+    8. This module-level function is provided to support older systems --- it
+    uses the :data:`libobjc` function if available, and otherwise emulates it.
 
 .. autofunction:: get_class
 .. autofunction:: should_use_stret

--- a/docs/reference/rubicon-objc-types.rst
+++ b/docs/reference/rubicon-objc-types.rst
@@ -4,7 +4,8 @@
 
 .. module:: rubicon.objc.types
 
-This module contains definitions for common C constants and types, and utilities for working with C types.
+This module contains definitions for common C constants and types, and
+utilities for working with C types.
 
 Common C type definitions
 -------------------------
@@ -13,23 +14,38 @@ These are commonly used C types from various frameworks.
 
 .. class:: c_ptrdiff_t([value])
 
-    The `ptrdiff_t <https://en.cppreference.com/w/c/types/ptrdiff_t>`__ type from ``<stddef.h>``. Equivalent to :class:`~ctypes.c_long` on 64-bit systems and :class:`~ctypes.c_int` on 32-bit systems.
+    The `ptrdiff_t <https://en.cppreference.com/w/c/types/ptrdiff_t>`__ type
+    from ``<stddef.h>``. Equivalent to :class:`~ctypes.c_long` on 64-bit
+    systems and :class:`~ctypes.c_int` on 32-bit systems.
 
 .. class:: NSInteger([value])
 
-    The `NSInteger <https://developer.apple.com/documentation/objectivec/nsinteger?language=objc>`__ type from ``<objc/NSObjCRuntime.h>``. Equivalent to :class:`~ctypes.c_long` on 64-bit systems and :class:`~ctypes.c_int` on 32-bit systems.
+    The `NSInteger
+    <https://developer.apple.com/documentation/objectivec/nsinteger?language=objc>`__
+    type from ``<objc/NSObjCRuntime.h>``. Equivalent to :class:`~ctypes.c_long`
+    on 64-bit systems and :class:`~ctypes.c_int` on 32-bit systems.
 
 .. class:: NSUInteger([value])
 
-    The `NSUInteger <https://developer.apple.com/documentation/objectivec/nsuinteger?language=objc>`__ type from ``<objc/NSObjCRuntime.h>``. Equivalent to :class:`~ctypes.c_ulong` on 64-bit systems and :class:`~ctypes.c_uint` on 32-bit systems.
+    The `NSUInteger
+    <https://developer.apple.com/documentation/objectivec/nsuinteger?language=objc>`__
+    type from ``<objc/NSObjCRuntime.h>``. Equivalent to
+    :class:`~ctypes.c_ulong` on 64-bit systems and :class:`~ctypes.c_uint` on
+    32-bit systems.
 
 .. class:: CGFloat([value])
 
-    The `CGFloat <https://developer.apple.com/documentation/corefoundation/cgfloat?language=objc>`__ type from ``<CoreGraphics/CGBase.h>``. Equivalent to :class:`~ctypes.c_double` on 64-bit systems and :class:`~ctypes.c_float` on 32-bit systems.
+    The `CGFloat
+    <https://developer.apple.com/documentation/corefoundation/cgfloat?language=objc>`__
+    type from ``<CoreGraphics/CGBase.h>``. Equivalent to
+    :class:`~ctypes.c_double` on 64-bit systems and :class:`~ctypes.c_float` on
+    32-bit systems.
 
 .. class:: NSPoint([x, y])
 
-    The `NSPoint <https://developer.apple.com/documentation/foundation/nspoint?language=objc>`__ structure from ``<Foundation/NSGeometry.h>``.
+    The `NSPoint
+    <https://developer.apple.com/documentation/foundation/nspoint?language=objc>`__
+    structure from ``<Foundation/NSGeometry.h>``.
 
     .. note::
 
@@ -43,7 +59,9 @@ These are commonly used C types from various frameworks.
 
 .. class:: CGPoint([x, y])
 
-    The `CGPoint <https://developer.apple.com/documentation/corefoundation/cgpoint?language=objc>`__ structure from ``<CoreGraphics/CGGeometry.h>``.
+    The `CGPoint
+    <https://developer.apple.com/documentation/corefoundation/cgpoint?language=objc>`__
+    structure from ``<CoreGraphics/CGGeometry.h>``.
 
     .. attribute::
         x
@@ -53,7 +71,9 @@ These are commonly used C types from various frameworks.
 
 .. class:: NSSize([width, height])
 
-    The `NSSize <https://developer.apple.com/documentation/foundation/nssize?language=objc>`__ structure from ``<Foundation/NSGeometry.h>``.
+    The `NSSize
+    <https://developer.apple.com/documentation/foundation/nssize?language=objc>`__
+    structure from ``<Foundation/NSGeometry.h>``.
 
     .. note::
 
@@ -67,7 +87,9 @@ These are commonly used C types from various frameworks.
 
 .. class:: CGSize([width, height])
 
-    The `CGSize <https://developer.apple.com/documentation/corefoundation/cgsize?language=objc>`__ structure from ``<CoreGraphics/CGGeometry.h>``.
+    The `CGSize
+    <https://developer.apple.com/documentation/corefoundation/cgsize?language=objc>`__
+    structure from ``<CoreGraphics/CGGeometry.h>``.
 
     .. attribute::
         width
@@ -77,7 +99,9 @@ These are commonly used C types from various frameworks.
 
 .. class:: NSRect([origin, size])
 
-    The `NSRect <https://developer.apple.com/documentation/foundation/nsrect?language=objc>`__ structure from ``<Foundation/NSGeometry.h>``.
+    The `NSRect
+    <https://developer.apple.com/documentation/foundation/nsrect?language=objc>`__
+    structure from ``<Foundation/NSGeometry.h>``.
 
     .. note::
 
@@ -93,7 +117,9 @@ These are commonly used C types from various frameworks.
 
 .. class:: CGRect([origin, size])
 
-    The `CGRect <https://developer.apple.com/documentation/corefoundation/cgrect?language=objc>`__ structure from ``<CoreGraphics/CGGeometry.h>``.
+    The `CGRect
+    <https://developer.apple.com/documentation/corefoundation/cgrect?language=objc>`__
+    structure from ``<CoreGraphics/CGGeometry.h>``.
 
     .. attribute:: origin
 
@@ -105,7 +131,9 @@ These are commonly used C types from various frameworks.
 
 .. class:: UIEdgeInsets([top, left, bottom, right])
 
-    The `UIEdgeInsets <https://developer.apple.com/documentation/uikit/uiedgeinsets?language=objc>`__ structure from ``<UIKit/UIGeometry.h>``.
+    The `UIEdgeInsets
+    <https://developer.apple.com/documentation/uikit/uiedgeinsets?language=objc>`__
+    structure from ``<UIKit/UIGeometry.h>``.
 
     .. attribute::
         top
@@ -117,7 +145,9 @@ These are commonly used C types from various frameworks.
 
 .. class:: NSEdgeInsets([top, left, bottom, right])
 
-    The `NSEdgeInsets <https://developer.apple.com/documentation/foundation/nsedgeinsets?language=objc>`__ structure from ``<Foundation/NSGeometry.h>``.
+    The `NSEdgeInsets
+    <https://developer.apple.com/documentation/foundation/nsedgeinsets?language=objc>`__
+    structure from ``<Foundation/NSGeometry.h>``.
 
     .. attribute::
         top
@@ -129,27 +159,43 @@ These are commonly used C types from various frameworks.
 
 .. class:: NSTimeInterval([value])
 
-    The `NSTimeInterval <https://developer.apple.com/documentation/foundation/nstimeinterval?language=objc>`__ type from ``<Foundation/NSDate.h>``. Equivalent to :class:`~ctypes.c_double`.
+    The `NSTimeInterval
+    <https://developer.apple.com/documentation/foundation/nstimeinterval?language=objc>`__
+    type from ``<Foundation/NSDate.h>``. Equivalent to :class:`~ctypes.c_double`.
 
 .. class:: CFIndex([value])
 
-    The `CFIndex <https://developer.apple.com/documentation/corefoundation/cfindex?language=objc>`__ type from ``<CoreFoundation/CFBase.h>``. Equivalent to :class:`~ctypes.c_longlong` on 64-bit systems and :class:`~ctypes.c_long` on 32-bit systems.
+    The `CFIndex
+    <https://developer.apple.com/documentation/corefoundation/cfindex?language=objc>`__
+    type from ``<CoreFoundation/CFBase.h>``. Equivalent to
+    :class:`~ctypes.c_longlong` on 64-bit systems and
+    :class:`~ctypes.c_long` on 32-bit systems.
 
 .. class:: UniChar([value])
 
-    The `UniChar <https://developer.apple.com/documentation/kernel/unichar?language=objc>`__ type from ``<MacTypes.h>``. Equivalent to :class:`~ctypes.c_ushort`.
+    The `UniChar
+    <https://developer.apple.com/documentation/kernel/unichar?language=objc>`__
+    type from ``<MacTypes.h>``. Equivalent to :class:`~ctypes.c_ushort`.
 
 .. class:: unichar([value])
 
-    The `unichar <https://developer.apple.com/documentation/foundation/unichar?language=objc>`__ type from ``<Foundation/NSString.h>``. Equivalent to :class:`~ctypes.c_ushort`.
+    The `unichar
+    <https://developer.apple.com/documentation/foundation/unichar?language=objc>`__
+    type from ``<Foundation/NSString.h>``. Equivalent to
+    :class:`~ctypes.c_ushort`.
 
 .. class:: CGGlyph([value])
 
-    The `CGGlyph <https://developer.apple.com/documentation/coregraphics/cgglyph?language=objc>`__ type from ``<CoreGraphics/CGFont.h>``. Equivalent to :class:`~ctypes.c_ushort`.
+    The `CGGlyph
+    <https://developer.apple.com/documentation/coregraphics/cgglyph?language=objc>`__
+    type from ``<CoreGraphics/CGFont.h>``. Equivalent to
+    :class:`~ctypes.c_ushort`.
 
 .. class:: CFRange([location, length])
 
-    The `CFRange <https://developer.apple.com/documentation/corefoundation/cfrange?language=objc>`__ type from ``<CoreFoundation/CFBase.h>``.
+    The `CFRange
+    <https://developer.apple.com/documentation/corefoundation/cfrange?language=objc>`__
+    type from ``<CoreFoundation/CFBase.h>``.
 
     .. attribute::
         location
@@ -159,7 +205,9 @@ These are commonly used C types from various frameworks.
 
 .. class:: NSRange([location, length])
 
-    The `NSRange <https://developer.apple.com/documentation/foundation/nsrange?language=objc>`__ type from ``<Foundation/NSRange.h>``.
+    The `NSRange
+    <https://developer.apple.com/documentation/foundation/nsrange?language=objc>`__
+    type from ``<Foundation/NSRange.h>``.
 
     .. attribute::
         location
@@ -174,28 +222,42 @@ These are commonly used C constants from various frameworks.
 
 .. data:: UIEdgeInsetsZero
 
-    The constant `UIEdgeInsetsZero <https://developer.apple.com/documentation/uikit/uiedgeinsetszero?language=objc>`__: a :class:`UIEdgeInsets` instance with all insets set to zero.
+    The constant `UIEdgeInsetsZero
+    <https://developer.apple.com/documentation/uikit/uiedgeinsetszero?language=objc>`__:
+    a :class:`UIEdgeInsets` instance with all insets set to zero.
 
 .. data:: NSZeroPoint
 
-    The constant `NSZeroPoint <https://developer.apple.com/documentation/foundation/nszeropoint?language=objc>`__: a :class:`NSPoint` instance with the X and Y coordinates set to zero.
+    The constant `NSZeroPoint
+    <https://developer.apple.com/documentation/foundation/nszeropoint?language=objc>`__:
+    a :class:`NSPoint` instance with the X and Y coordinates set to zero.
 
 .. data:: NSIntegerMax
 
-    The macro constant `NSIntegerMax <https://developer.apple.com/documentation/objectivec/nsintegermax?language=objc>`__ from ``<objc/NSObjCRuntime.h>``: the maximum value that a :class:`NSInteger` can hold.
+    The macro constant `NSIntegerMax
+    <https://developer.apple.com/documentation/objectivec/nsintegermax?language=objc>`__
+    from ``<objc/NSObjCRuntime.h>``: the maximum value that a
+    :class:`NSInteger` can hold.
 
 .. data:: NSNotFound
 
-    The constant `NSNotFound <https://developer.apple.com/documentation/foundation/nsnotfound?language=objc>`__ from ``<Foundation/NSObjCRuntime.h>``: a :class:`NSInteger` sentinel value indicating that an item was not found (usually when searching in a collection).
+    The constant `NSNotFound
+    <https://developer.apple.com/documentation/foundation/nsnotfound?language=objc>`__
+    from ``<Foundation/NSObjCRuntime.h>``: a :class:`NSInteger` sentinel value
+    indicating that an item was not found (usually when searching in a
+    collection).
 
 Architecture detection constants
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The following constants provide information about the architecture of the current environment. All of them are equivalent to the C compiler macros of the same names.
+The following constants provide information about the architecture of the
+current environment. All of them are equivalent to the C compiler macros of the
+same names.
 
 .. data:: __LP64__
 
-    Indicates whether the current environment is 64-bit. If true, C ``long``\s and pointers are 64 bits in size, otherwise 32 bits.
+    Indicates whether the current environment is 64-bit. If true, C ``long``\s
+    and pointers are 64 bits in size, otherwise 32 bits.
 
 .. data::
     __i386__
@@ -203,14 +265,19 @@ The following constants provide information about the architecture of the curren
     __arm__
     __arm64__
 
-    Each of these constants is true if the current environment uses the named architecture. At most one of these constants is true at once in a single Python runtime. (If the current architecture cannot be determined, all of these constants are false.)
+    Each of these constants is true if the current environment uses the named
+    architecture. At most one of these constants is true at once in a single
+    Python runtime. (If the current architecture cannot be determined, all of
+    these constants are false.)
 
 Objective-C type encoding conversion
 ------------------------------------
 
-These functions are used to convert Objective-C type encoding strings to and from :mod:`ctypes` types, and to manage custom conversions in both directions.
+These functions are used to convert Objective-C type encoding strings to and
+from :mod:`ctypes` types, and to manage custom conversions in both directions.
 
-All Objective-C encoding strings are represented as :class:`bytes` rather than :class:`str`.
+All Objective-C encoding strings are represented as :class:`bytes` rather than
+:class:`str`.
 
 .. autofunction:: ctype_for_encoding
 .. autofunction:: encoding_for_ctype
@@ -230,13 +297,15 @@ All Objective-C encoding strings are represented as :class:`bytes` rather than :
 Default registered type encodings
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The following table lists Objective-C's standard type encodings for primitive types, and the corresponding registered
-ctypes. These mappings can be considered stable, but nonetheless users should not hard code these encodings unless
-necessary. Instead, the :func:`encoding_for_ctype` function should be used to encode types, because it is less
-error-prone and more readable than typing encodings out by hand.
+The following table lists Objective-C's standard type encodings for primitive
+types, and the corresponding registered ctypes. These mappings can be
+considered stable, but nonetheless users should not hard code these encodings
+unless necessary. Instead, the :func:`encoding_for_ctype` function should be
+used to encode types, because it is less error-prone and more readable than
+typing encodings out by hand.
 
 ========================================= ========================== =====
-`Ctype`                                   Type encoding              Notes
+``Ctype``                                 Type encoding              Notes
 ========================================= ========================== =====
 ``None`` (``void``)                       ``v``
 :class:`~ctypes.c_bool`                   ``B``                      This refers to the ``bool`` type from C99 and C++. It is not necessarily the same as the `BOOL` type, which may be either :class:`~ctypes.c_byte` or :class:`~ctypes.c_bool` depending on the system and architecture.
@@ -298,14 +367,22 @@ and architecture:
 Conversion of Python sequences to C structures and arrays
 ---------------------------------------------------------
 
-This function is used to convert a Python sequence (such as a :class:`tuple` or :class:`list`) to a specific C structure or array type. This function is mainly used internally by Rubicon, to allow passing Python sequences as method parameters where a C structure or array would normally be required. Most users will not need to use this function directly.
+This function is used to convert a Python sequence (such as a :class:`tuple` or
+:class:`list`) to a specific C structure or array type. This function is mainly
+used internally by Rubicon, to allow passing Python sequences as method
+parameters where a C structure or array would normally be required. Most users
+will not need to use this function directly.
 
 .. autofunction:: compound_value_for_sequence
 
 Python to :mod:`ctypes` type mapping
 ------------------------------------
 
-These functions are used to map Python types to equivalent :mod:`ctypes` types, and to add or remove such mappings. This mechanism is mainly used internally by Rubicon, to for example allow :class:`~rubicon.objc.api.ObjCInstance` to be used instead of :class:`~rubicon.objc.runtime.objc_id` in method type annotations. Most users will not need to use these functions directly.
+These functions are used to map Python types to equivalent :mod:`ctypes` types,
+and to add or remove such mappings. This mechanism is mainly used internally by
+Rubicon, to for example allow :class:`~rubicon.objc.api.ObjCInstance` to be
+used instead of :class:`~rubicon.objc.runtime.objc_id` in method type
+annotations. Most users will not need to use these functions directly.
 
 .. autofunction:: ctype_for_type
 .. autofunction:: register_ctype_for_type

--- a/docs/reference/rubicon-objc.rst
+++ b/docs/reference/rubicon-objc.rst
@@ -4,12 +4,19 @@
 
 .. module:: rubicon.objc
 
-This is the main namespace of Rubicon-ObjC. Rubicon is structured into multiple submodules of :mod:`rubicon.objc`, and the most commonly used attributes from these submodules are exported via the :mod:`rubicon.objc` module. This means that most users only need to import and use the main :mod:`rubicon.objc` module; the individual submodules only need to be used for attributes that are not also available on :mod:`rubicon.objc`.
+This is the main namespace of Rubicon-ObjC. Rubicon is structured into multiple
+submodules of :mod:`rubicon.objc`, and the most commonly used attributes from
+these submodules are exported via the :mod:`rubicon.objc` module. This means
+that most users only need to import and use the main :mod:`rubicon.objc`
+module; the individual submodules only need to be used for attributes that are
+not also available on :mod:`rubicon.objc`.
 
 Exported Attributes
 -------------------
 
-This is a full list of all attributes exported on the :mod:`rubicon.objc` module. For detailed documentation on these attributes, click the links below to visit the relevant sections of the submodules' documentation.
+This is a full list of all attributes exported on the :mod:`rubicon.objc`
+module. For detailed documentation on these attributes, click the links below
+to visit the relevant sections of the submodules' documentation.
 
 From :mod:`rubicon.objc.api`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/tutorial/tutorial-1.rst
+++ b/docs/tutorial/tutorial-1.rst
@@ -5,7 +5,7 @@ Your first bridge
 =================
 
 In this example, we're going to use Rubicon to access the Objective-C
-Foundation library, and the `NSURL` class in that library. `NSURL` is the
+Foundation library, and the ``NSURL`` class in that library. ``NSURL`` is the
 class used to represent and manipulate URLs.
 
 This tutorial assumes you've set up your environment as described in the
@@ -15,44 +15,50 @@ Accessing NSURL
 ===============
 
 Start Python, and get a reference to an Objective-C class. In this example,
-we're going to use the `NSURL` class, Objective-C's representation of URLs:
+we're going to use the ``NSURL`` class, Objective-C's representation of URLs:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from rubicon.objc import ObjCClass
     >>> NSURL = ObjCClass("NSURL")
 
-This gives us an `NSURL` class in Python which is transparently bridged to the
-`NSURL` class in the Objective-C runtime. Any method or property described in
-`Apple's documentation on NSURL
-<https://developer.apple.com/documentation/foundation/nsurl?language=objc>`__  can
-be accessed over this bridge.
+This gives us an ``NSURL`` class in Python which is transparently bridged to
+the ``NSURL`` class in the Objective-C runtime. Any method or property
+described in `Apple's documentation on NSURL
+<https://developer.apple.com/documentation/foundation/nsurl?language=objc>`__
+can be accessed over this bridge.
 
-Let's create an instance of an `NSURL` object. The `NSURL` documentation
-describes a static constructor `+URLWithString:`; we can invoke this
-constructor as::
+Let's create an instance of an ``NSURL`` object. The ``NSURL`` documentation
+describes a static constructor ``+URLWithString:``; we can invoke this
+constructor as:
+
+.. code-block:: pycon
 
     >>> base = NSURL.URLWithString("https://beeware.org/")
 
 That is, the name of the method in Python is identical to the method in
-Objective-C. The first argument is declared as being an `NSString *`; Rubicon
-converts the Python `str` into an `NSString` instance as part of invoking the
-method.
+Objective-C. The first argument is declared as being an ``NSString *``; Rubicon
+converts the Python :class:`str` into an ``NSString`` instance as part of
+invoking the method.
 
-`NSURL` has another static constructor: `+URLWithString:relativeToURL:`. We
+``NSURL`` has another static constructor: ``+URLWithString:relativeToURL:``. We
 can also invoke this constructor:
+
+.. code-block:: pycon
 
     >>> full = NSURL.URLWithString("contributing/", relativeToURL=base)
 
-The second argument (`relativeToURL`) is accessed as a keyword argument. This
-argument is declared as being of type `NSURL *`; since `base` is an instance
-of NSURL, Rubicon can pass through this instance.
+The second argument (``relativeToURL``) is accessed as a keyword argument. This
+argument is declared as being of type ``NSURL *``; since ``base`` is an
+instance of ``NSURL``, Rubicon can pass through this instance.
 
 Sometimes, an Objective-C method definition will use the same keyword
 argument name twice. This is legal in Objective-C, but not in Python, as you
 can't repeat a keyword argument in a method call. In this case, you can use a
 "long form" of the method to explicitly invoke a descriptor by replacing
-colons with underscores::
+colons with underscores:
+
+.. code-block:: pycon
 
     >>> base = NSURL.URLWithString_("https://beeware.org/")
     >>> full = NSURL.URLWithString_relativeToURL_("contributing", base)
@@ -60,25 +66,33 @@ colons with underscores::
 Instance methods
 ================
 
-So far, we've been using the `+URLWithString:` static constructor. However,
-`NSURL` also provides an initializer method `-initWithString:`. To use this
+So far, we've been using the ``+URLWithString:`` static constructor. However,
+``NSURL`` also provides an initializer method ``-initWithString:``. To use this
 method, you first have to instruct the Objective-C runtime to allocate memory
 for the instance, then invoke the initializer:
 
+.. code-block:: pycon
+
     >>> base = NSURL.alloc().initWithString("https://beeware.org/")
 
-Now that you have an instance of `NSURL`, you'll want to manipulate it.
-`NSURL` describes an `absoluteURL` property; this property can be
-accessed as a Python attribute::
+Now that you have an instance of ``NSURL``, you'll want to manipulate it.
+``NSURL`` describes an ``absoluteURL`` property; this property can be accessed
+as a Python attribute:
+
+.. code-block:: pycon
 
     >>> absolute = full.absoluteURL
 
-You can also invoke methods on the instance::
+You can also invoke methods on the instance:
+
+.. code-block:: pycon
 
     >>> longer = absolute.URLByAppendingPathComponent('how/first-time/')
 
 If you want to output an object at the console, you can use the Objective-C
-property `description`, or for debugging output, `debugDescription`::
+property ``description``, or for debugging output, ``debugDescription``:
+
+.. code-block:: pycon
 
     >>> longer.description
     'https://beeware.org/contributing/how/first-time/'
@@ -86,8 +100,10 @@ property `description`, or for debugging output, `debugDescription`::
     >>> longer.debugDescription
     'https://beeware.org/contributing/how/first-time/>'
 
-Internally, `description` and `debugDescription` are hooked up to their Python
-equivalents, `__str__()` and `__repr__()`, respectively::
+Internally, ``description`` and ``debugDescription`` are hooked up to their
+Python equivalents, ``__str__()`` and ``__repr__()``, respectively:
+
+.. code-block:: pycon
 
     >>> str(absolute)
     'https://beeware.org/contributing/how/first-time/'

--- a/docs/tutorial/tutorial-2.rst
+++ b/docs/tutorial/tutorial-2.rst
@@ -7,12 +7,13 @@ a class instance as an argument. For example, when using macOS and iOS GUI
 classes, you often need to define "delegate" classes to describe how a GUI
 element will respond to mouse clicks and key presses.
 
-Let's define a `Handler` class, with two methods:
+Let's define a ``Handler`` class, with two methods:
 
-    * an `-initWithValue:` constructor that accepts an integer; and
+    * an ``-initWithValue:`` constructor that accepts an integer; and
 
-    * a `-pokeWithValue:andName:` method that accepts an integer and a string,
-      prints the string, and returns a float that is one half of the value.
+    * a ``-pokeWithValue:andName:`` method that accepts an integer and a
+      string, prints the string, and returns a float that is one half of the
+      value.
 
 The declaration for this class would be::
 
@@ -32,33 +33,35 @@ The declaration for this class would be::
 
 This code has several interesting implementation details:
 
-    * The `Handler` class extends `NSObject`. This instructs Rubicon to
+    * The ``Handler`` class extends ``NSObject``. This instructs Rubicon to
       construct the class in a way that it can be registered with the
       Objective-C runtime.
 
     * Each method that we want to expose to Objective-C is decorated with
-      `@objc_method`.The method names match the Objective-C descriptor that
+      ``@objc_method``.The method names match the Objective-C descriptor that
       you want to expose, but with colons replaced by underscores. This matches
       the "long form" way of invoking methods discussed in :doc:`tutorial-1`.
 
-    * The `v` argument on `initWithValue_()` uses a Python 3 type annotation
-      to declare it's type. Objective-C is a language with static typing, so
-      any methods defined in Python must provide this typing information.
-      Any argument that isn't annotated is assumed to be of type `id` - that is,
-      a pointer to an Objective-C object.
+    * The ``v`` argument on ``initWithValue_()`` uses a Python 3 type
+      annotation to declare it's type. Objective-C is a language with static
+      typing, so any methods defined in Python must provide this typing
+      information. Any argument that isn't annotated is assumed to be of type
+      ``id`` - that is, a pointer to an Objective-C object.
 
-    * The `pokeWithValue_andName_()` method has it's integer argument
+    * The ``pokeWithValue_andName_()`` method has it's integer argument
       annotated, and has it's return type annotated as float. Again, this is
       to support Objective-C typing operations. Any function that has no
-      return type annotation is assumed to return `id`. A return type
-      annotation of `None` will be interpreted as a `void` method in
-      Objective-C. The `name` argument doesn't need to be annotated because it
-      will be passed in as a string, and strings are `NSObject` subclasses
+      return type annotation is assumed to return ``id``. A return type
+      annotation of ``None`` will be interpreted as a ``void`` method in
+      Objective-C. The ``name`` argument doesn't need to be annotated because it
+      will be passed in as a string, and strings are ``NSObject`` subclasses
       in Objective-C.
 
-    * `initWithValue_()` is a constructor, so it returns `self`.
+    * ``initWithValue_()`` is a constructor, so it returns ``self``.
 
-Having declared the class, you can then instantiate and use it::
+Having declared the class, you can then instantiate and use it:
+
+.. code-block:: pycon
 
     >>> my_handler = Handler.alloc().initWithValue(42)
     >>> print(my_handler.value)
@@ -70,15 +73,14 @@ Having declared the class, you can then instantiate and use it::
 Objective-C properties
 ======================
 
-When we defined the initializer for `Handler`, we stored the provided value
-as the `value` attribute of the class. However, as this attribute wasn't
+When we defined the initializer for ``Handler``, we stored the provided value
+as the ``value`` attribute of the class. However, as this attribute wasn't
 declared to Objective-C, it won't be visible to the Objective-C runtime.
-You can access `value` from within Python - but Objective-C code won't be able
-to access it.
+You can access ``value`` from within Python - but Objective-C code won't be
+able to access it.
 
 To expose value to the Objective-C runtime, we need to make one small change,
 and explicitly declare value as an Objective-C property::
-
 
     from rubicon.objc import NSObject, objc_method, objc_property()
 
@@ -97,10 +99,12 @@ Class naming
 ============
 
 In this revised example, you'll note that we also used a different class name
-- `PureHandler`. This was deliberate, because Objective-C doesn't have any
+- ``PureHandler``. This was deliberate, because Objective-C doesn't have any
 concept of namespaces. As a result, you can only define one class of any given
-name in a process - so, you wont be able to define a second `Handler` class in
-the same Python shell. If you try, you'll get an error::
+name in a process - so, you wont be able to define a second ``Handler`` class in
+the same Python shell. If you try, you'll get an error:
+
+.. code-block:: pycon
 
     >>> class Handler(NSObject):
     ...     pass
@@ -111,14 +115,14 @@ the same Python shell. If you try, you'll get an error::
 You'll need to be careful (and sometimes, painfully verbose) when choosing class
 names.
 
-What, no `__init__()`?
-======================
+What, no ``__init__()``?
+========================
 
-You'll also notice that our example code *doesn't* have an `__init__()` method
-like you'd normally expect of Python code. As we're defining an Objective-C
-class, we need to follow the Objective-C object life cycle - which means
-defining initializer methods that are visible to the Objective-C runtime, and
-invoking them over that bridge.
+You'll also notice that our example code *doesn't* have an ``__init__()``
+method like you'd normally expect of Python code. As we're defining an
+Objective-C class, we need to follow the Objective-C object life cycle - which
+means defining initializer methods that are visible to the Objective-C runtime,
+and invoking them over that bridge.
 
 Next steps
 ==========

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ docs =
     sphinx == 6.2.0
     sphinx_tabs == 3.4.1
     sphinx-autobuild == 2021.3.14
+    sphinx-copybutton == 0.5.2
     sphinxcontrib-spelling == 8.0.0
 
 [flake8]


### PR DESCRIPTION
## Changes
- Based on beeware/beeware#210, adds support for a copy button for code blocks.
- Ensures all code blocks use the appropriate lexer for the platform's commands.
- All pages were also reformatted to 80 chars
- Misc cleanup

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
