### PR TITLE
Use trusted publisher in publshing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      # This permission is required for trusted publishing.
+      id-token: write
     steps:
       - uses: dsaltares/fetch-gh-release-asset@1.1.0
         with:
@@ -20,5 +23,3 @@ jobs:
 
       - name: Publish release to production PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # This permission is required for trusted publishing.
+      id-token: write
     steps:
       - name: Get packages
         uses: actions/download-artifact@v3.0.2
@@ -67,4 +69,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository_url: https://test.pypi.org/legacy/
-          password: ${{ secrets.TEST_PYPI_PASSWORD }}

--- a/changes/301.misc.rst
+++ b/changes/301.misc.rst
@@ -1,0 +1,1 @@
+Release processes were changed to use Trusted Publishing.


### PR DESCRIPTION
Adds the `id-token: write` permission to the publishing workflow to take advantage of trusted publishers.

Related to: https://github.com/beeware/beeware/issues/219

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
