### PR TITLE
Add support for PEP563 deferred annotations

### DIFF
--- a/changes/308.bugfix.rst
+++ b/changes/308.bugfix.rst
@@ -1,0 +1,1 @@
+Rubicon is now compatible with PEP563 deferred annotations (``from __future__ import annotations``).

--- a/docs/background/releases.rst
+++ b/docs/background/releases.rst
@@ -3,12 +3,6 @@ Release History
 
 .. towncrier release notes start
 
-0.4.7.dev0+g3fb9aa5.d20230512 (2023-05-12)
-==========================================
-
-No significant changes.
-
-
 0.4.6 (2023-04-14)
 ==================
 

--- a/docs/background/releases.rst
+++ b/docs/background/releases.rst
@@ -3,6 +3,12 @@ Release History
 
 .. towncrier release notes start
 
+0.4.7.dev0+g3fb9aa5.d20230512 (2023-05-12)
+==========================================
+
+No significant changes.
+
+
 0.4.6 (2023-04-14)
 ==================
 

--- a/src/rubicon/objc/api.py
+++ b/src/rubicon/objc/api.py
@@ -94,15 +94,7 @@ _keep_alive_objects = {}
 
 def encoding_from_annotation(f, offset=1):
     argspec = inspect.getfullargspec(inspect.unwrap(f))
-    # typing evaluates a return type of None as <class NoneType>;
-    # convert that back to a None. E721 is the "don't compare types,
-    # use isinstance()" flake8 error. Which is good advice... except
-    # that we're not checking an instance - we *are* comparing types.
-    hints = {
-        var: None if hint == type(None) else hint  # noqa: E721
-        for var, hint in typing.get_type_hints(f).items()
-    }
-
+    hints = typing.get_type_hints(f)
     encoding = [hints.get("return", ObjCInstance), ObjCInstance, SEL]
 
     for varname in argspec.args[offset:]:

--- a/src/rubicon/objc/types.py
+++ b/src/rubicon/objc/types.py
@@ -114,6 +114,7 @@ __arm__ = _any_arm and not __LP64__
 
 
 _ctype_for_type_map = {
+    type(None): None,
     int: c_int,
     float: c_double,
     bool: c_bool,

--- a/tests/test_NSArray.py
+++ b/tests/test_NSArray.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import unittest
 
 from rubicon.objc import (

--- a/tests/test_NSDictionary.py
+++ b/tests/test_NSDictionary.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import unittest
 
 from rubicon.objc import (

--- a/tests/test_NSString.py
+++ b/tests/test_NSString.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import unittest
 

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import time
 import unittest

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import platform
 import unittest
 from ctypes import Structure, c_int, c_void_p
@@ -104,11 +106,21 @@ class BlockTests(unittest.TestCase):
         self.assertEqual(values, [27])
         self.assertEqual(result, 42)
 
-    def test_block_receiver_unannotated(self):
+    def test_block_receiver_no_return_annotation(self):
         BlockReceiverExample = ObjCClass("BlockReceiverExample")
         instance = BlockReceiverExample.alloc().init()
 
-        def block(a, b):
+        def block(a: int, b: int):
+            return a + b
+
+        with self.assertRaises(ValueError):
+            instance.receiverMethod_(block)
+
+    def test_block_receiver_missing_arg_annotation(self):
+        BlockReceiverExample = ObjCClass("BlockReceiverExample")
+        instance = BlockReceiverExample.alloc().init()
+
+        def block(a: int, b) -> int:
             return a + b
 
         with self.assertRaises(ValueError):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import gc
 import math

--- a/tests/test_ctypes_patch.py
+++ b/tests/test_ctypes_patch.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ctypes
 import unittest
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = towncrier,towncrier-check,docs{,-lint,-all},package,py{36,37,38,39,310,311,312}
+envlist = towncrier-check,docs{,-lint,-all},py{37,38,39,310,311,312}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
PEP563 (`from __future__ import annotations`) introduced the idea of deferred annotations - type annotations on function declarations are now parsed as strings, with conversion into actual types being deferred until they are actually required.

This PR adds the changes to perform this annotation evaluation.

PEP563 is opt-in; the approach taken in this PR is compatible with both pre- and post PEP563 code. If code *doesn't* include the `__future__` import, the `typing.get_type_hints()` call returns the type annotations as-parsed.

Fixes #308.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
