### PR TITLE
Fix scroll issue #316

### DIFF
--- a/changes/317.bugfix.rst
+++ b/changes/317.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed iOS scroll issue `#316 <https://github.com/beeware/rubicon-objc/issues/316>`_
+iOS now uses a full NSRunLoop, rather than a CFRunLoop.

--- a/changes/317.bugfix.rst
+++ b/changes/317.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed iOS scroll issue `#316 <https://github.com/beeware/rubicon-objc/issues/316>`_

--- a/src/rubicon/objc/eventloop.py
+++ b/src/rubicon/objc/eventloop.py
@@ -79,6 +79,7 @@ kCFSocketWriteCallBack = 8
 kCFSocketAutomaticallyReenableReadCallBack = 1
 kCFSocketAutomaticallyReenableWriteCallBack = 8
 
+NSRunLoop = ObjCClass("NSRunLoop")
 
 ###########################################################################
 # CoreFoundation methods for async handlers
@@ -523,10 +524,10 @@ class CFEventLoop(unix_events.SelectorEventLoop):
             events._set_running_loop(self)
 
         # Start the lifecycle, but invoke it as a deferred event on the event
-        # loop. iOSLifeCycle.start() invokes libcf.CFRunLoopRun(); this ensures
-        # that a full CFRunLoop is running, not just one that responds to
+        # loop. iOSLifeCycle.start() starts the NSRunLoop; this ensures
+        # that a full NSRunLoop is running, not just one that responds to
         # iOS events. See #228 for the sort of behavior that occurs on threads
-        # if the CFRunLoop isn't started.
+        # if the NSRunLoop isn't started.
         self.call_soon(self._lifecycle.start)
 
     def call_soon(self, callback, *args, context=None):
@@ -751,7 +752,6 @@ class iOSLifecycle:
     """A life cycle manager for iOS (``UIApplication``) apps."""
 
     def start(self):
-        NSRunLoop = ObjCClass("NSRunLoop")
         NSRunLoop.currentRunLoop.run()
 
     def stop(self):

--- a/src/rubicon/objc/eventloop.py
+++ b/src/rubicon/objc/eventloop.py
@@ -12,7 +12,7 @@ from asyncio import (
 )
 from ctypes import CFUNCTYPE, POINTER, Structure, c_double, c_int, c_ulong, c_void_p
 
-from .api import objc_const, ObjCClass
+from .api import ObjCClass, objc_const
 from .runtime import load_library, objc_id
 from .types import CFIndex
 

--- a/src/rubicon/objc/eventloop.py
+++ b/src/rubicon/objc/eventloop.py
@@ -12,7 +12,7 @@ from asyncio import (
 )
 from ctypes import CFUNCTYPE, POINTER, Structure, c_double, c_int, c_ulong, c_void_p
 
-from .api import objc_const
+from .api import objc_const, ObjCClass
 from .runtime import load_library, objc_id
 from .types import CFIndex
 
@@ -751,7 +751,8 @@ class iOSLifecycle:
     """A life cycle manager for iOS (``UIApplication``) apps."""
 
     def start(self):
-        libcf.CFRunLoopRun()
+        NSRunLoop = ObjCClass("NSRunLoop")
+        NSRunLoop.currentRunLoop.run()
 
     def stop(self):
         libcf.CFRunLoopStop(libcf.CFRunLoopGetMain())


### PR DESCRIPTION
`CFRunLoopRun` causes the run loop to run in its default mode, but it seems like it's terminated when switching to another mode for example `UITrackingRunLoopMode` when the user scrolls.  I think the `NSRunLoop` class can properly handle switches between modes.

<!--- Describe your changes in detail -->
Switch `CFRunLoop` with `NSRunLoop` in `iOSLifecycle`

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #316 
## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
