### PR TITLE
Goodbye 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         platform: [ "macOS-11", "macOS-12" ]
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12-dev" ]
         include:
           - experimental: false
           - python-version: "3.12-dev"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     rev: v3.8.0
     hooks:
       - id: pyupgrade
-        args: [--py37-plus]
+        args: [--py38-plus]
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:

--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ Community
 
 Rubicon is part of the `BeeWare suite`_. You can talk to the community through:
 
-* `@pybeeware on Twitter <https://twitter.com/pybeeware>`__
+* `@beeware@fosstodon.org on Mastodon <https://fosstodon.org/@beeware>`__
 
 * `Discord <https://beeware.org/bee/chat/>`__
 

--- a/changes/334.removal.rst
+++ b/changes/334.removal.rst
@@ -1,0 +1,1 @@
+Support for Python 3.7 was dropped.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,6 +107,11 @@ nitpick_ignore = [
     ("py:func", "rubicon.objc.types.UIEdgeInsetsMake"),
 ]
 
+# 2023-07-10: Github Line number anchors fail link checks when retrieved by robots. This
+# drops the line number anchor from any link checks, but still validates the base URL is
+# valid.
+linkcheck_anchors_ignore = [r"L\d+"]
+
 # -- Options for copy button ---------------------------------------------------
 
 # virtual env prefix: (venv), (beeware-venv), (testenv)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,10 @@ package = "rubicon.objc"
 filename = "docs/background/releases.rst"
 title_format = "{version} ({project_date})"
 template = "changes/template.rst"
+type = [
+    { directory = "feature", name = "Features", showcontent = true },
+    { directory = "bugfix", name = "Bugfixes", showcontent = true },
+    { directory = "removal", name = "Backward Incompatible Changes", showcontent = true },
+    { directory = "doc", name = "Documentation", showcontent = true },
+    { directory = "misc", name = "Misc", showcontent = false },
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     License :: OSI Approved :: BSD License
     Programming Language :: Objective C
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -30,13 +29,10 @@ long_description = file: README.rst
 long_description_content_type = text/x-rst
 
 [options]
-python_requires = >=3.7
+python_requires = >=3.8
 packages = find_namespace:
 package_dir =
     = src
-install_requires =
-    # We need importlib.metadata.version, added in Python 3.8
-    importlib_metadata >= 4.4; python_version < "3.8"
 
 [options.packages.find]
 where = src
@@ -44,9 +40,7 @@ include = rubicon.*
 
 [options.extras_require]
 dev =
-    # Pre-commit 3.0 dropped support for Python 3.7
-    pre-commit == 2.21.0; python_version < "3.8"
-    pre-commit == 3.3.3; python_version >= "3.8"
+    pre-commit == 3.3.3
     pytest == 7.4.0
     pytest-tldr == 0.2.5
     setuptools_scm[toml] == 7.1.0

--- a/src/rubicon/objc/api.py
+++ b/src/rubicon/objc/api.py
@@ -1515,37 +1515,36 @@ class ObjCClass(ObjCInstance, type):
     def declare_property(self, name):
         """Declare the instance method ``name`` to be a property getter.
 
-        This causes the attribute named ``name`` on instances of this class to
-        be treated as a property rather than a method --- accessing it returns
-        the property's value, without requiring an explicit method call. See
-        :class:`ObjCInstance.__getattr__` for a full description of how
-        attribute access behaves for properties.
+        This causes the attribute named ``name`` on instances of this class to be
+        treated as a property rather than a method --- accessing it returns the
+        property's value, without requiring an explicit method call. See
+        :class:`ObjCInstance.__getattr__` for a full description of how attribute access
+        behaves for properties.
 
-        Most properties do not need to be declared explicitly using this method,
-        as they are detected automatically by :class:`ObjCInstance.__getattr__`.
-        This method only needs to be used for properties that are read-only and
-        don't have a ``@property`` declaration in the source code, because
-        Rubicon cannot tell such properties apart from normal zero-argument
-        methods.
+        Most properties do not need to be declared explicitly using this method, as they
+        are detected automatically by :class:`ObjCInstance.__getattr__`. This method
+        only needs to be used for properties that are read-only and don't have a
+        ``@property`` declaration in the source code, because Rubicon cannot tell such
+        properties apart from normal zero-argument methods.
 
         .. note::
 
-            In the standard Apple SDKs, some properties are introduced as
-            regular methods in one system version, and then declared as
-            properties in a later system version. For example, the
-            ``description`` method/property of :class:`NSObject` was declared as
-            a regular method `up to OS X 10.9
-            <https://github.com/phracker/MacOSX-SDKs/blob/9fc3ed0ad0345950ac25c28695b0427846eea966/MacOSX10.9.sdk/usr/include/objc/NSObject.h#L40>`__,
-            but changed to a property `as of OS X 10.10
-            <https://github.com/phracker/MacOSX-SDKs/blob/9fc3ed0ad0345950ac25c28695b0427846eea966/MacOSX10.10.sdk/usr/include/objc/NSObject.h#L43>`__.
+            In the standard Apple SDKs, some properties are introduced as regular
+            methods in one system version, and then declared as properties in a later
+            system version. For example, the ``description`` method/property of
+            :class:`NSObject` was declared as a regular method up to macOS 10.9, but
+            changed to a property as of macOS 10.10.
 
-            Such properties cause compatibility issues when accessed from
-            Rubicon: ``obj.description()`` works on 10.9 but is a
-            :class:`TypeError` on 10.10, whereas ``obj.description`` works on
-            10.10 but returns a method object on 10.9. To solve this issue, the
-            property can be declared explicitly using
-            ``NSObject.declare_property('description')``, so that it can always
-            be accessed using ``obj.description``.
+            Such properties cause compatibility issues when accessed from Rubicon.
+            ``obj.description()`` works on 10.9 but is a :class:`TypeError` on 10.10,
+            whereas ``obj.description`` works on 10.10 but returns a method object on
+            10.9. To solve this issue, the property can be declared explicitly using
+            ``NSObject.declare_property('description')``, so that it can always be
+            accessed using ``obj.description``.
+
+            The `MacOSX-SDKs Github repository
+            <https://github.com/phracker/MacOSX-SDKs>`__ can be a useful resource for
+            identifying when changes like this have occurred.
         """
 
         self.forced_properties.add(name)

--- a/src/rubicon/objc/api.py
+++ b/src/rubicon/objc/api.py
@@ -1532,19 +1532,17 @@ class ObjCClass(ObjCInstance, type):
             In the standard Apple SDKs, some properties are introduced as regular
             methods in one system version, and then declared as properties in a later
             system version. For example, the ``description`` method/property of
-            :class:`NSObject` was declared as a regular method up to macOS 10.9, but
-            changed to a property as of macOS 10.10.
+            :class:`NSObject` was declared as a regular method `up to OS X 10.9
+            <https://github.com/phracker/MacOSX-SDKs/blob/9fc3ed0ad0345950ac25c28695b0427846eea966/MacOSX10.9.sdk/usr/include/objc/NSObject.h#L40>`__,
+            but changed to a property `as of OS X 10.10
+            <https://github.com/phracker/MacOSX-SDKs/blob/9fc3ed0ad0345950ac25c28695b0427846eea966/MacOSX10.10.sdk/usr/include/objc/NSObject.h#L43>`__.
 
-            Such properties cause compatibility issues when accessed from Rubicon.
+            Such properties cause compatibility issues when accessed from Rubicon:
             ``obj.description()`` works on 10.9 but is a :class:`TypeError` on 10.10,
             whereas ``obj.description`` works on 10.10 but returns a method object on
             10.9. To solve this issue, the property can be declared explicitly using
             ``NSObject.declare_property('description')``, so that it can always be
             accessed using ``obj.description``.
-
-            The `MacOSX-SDKs Github repository
-            <https://github.com/phracker/MacOSX-SDKs>`__ can be a useful resource for
-            identifying when changes like this have occurred.
         """
 
         self.forced_properties.add(name)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = towncrier-check,docs{,-lint,-all},py{37,38,39,310,311,312}
+envlist = towncrier-check,docs{,-lint,-all},py{38,39,310,311,312}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
Python 3.7 is [officially EOL](https://devguide.python.org/versions/), so we can remove it from the list of tested and officially supported versions.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
