### PR TITLE
Add Sphinx pin for Python 3.8

### DIFF
--- a/changes/351.misc.rst
+++ b/changes/351.misc.rst
@@ -1,0 +1,1 @@
+A separate Sphinx pin was added for Python 3.8, because Sphinx 7.2 deprecated support for Python 3.8.

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,9 @@ dev =
 docs =
     furo == 2023.8.19
     pyenchant == 3.2.2
-    sphinx == 7.2.2
+    # Sphinx 7.2 deprecated support for Python 3.8
+    sphinx == 7.1.2 ; python_version < '3.9'
+    sphinx == 7.2.2 ; python_version >= '3.9'
     sphinx_tabs == 3.4.1
     sphinx-autobuild == 2021.3.14
     sphinx-copybutton == 0.5.2


### PR DESCRIPTION
Fixes #351 

Sphinx 7.2.2 dropped support for Python 3.8. This PR adds a pin for Sphinx so that docs can still be built on Py3.8.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
