### PR TITLE
Correct block handling on M1 hardware

### DIFF
--- a/changes/225.bugfix.rst
+++ b/changes/225.bugfix.rst
@@ -1,0 +1,1 @@
+References to blocks obtained from an Objective C API can now be invoked on M1 hardware.

--- a/changes/225.feature.rst
+++ b/changes/225.feature.rst
@@ -1,0 +1,1 @@
+``objc_id`` and ``objc_block`` are now exposed as part of the ``rubicon.objc`` namespace, rather than requiring an import from ``rubicon.objc.runtime``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,7 +40,7 @@ Community
 
 Rubicon is part of the `BeeWare suite <https://beeware.org>`__. You can talk to the community through:
 
-* `@pybeeware on Twitter <https://twitter.com/pybeeware>`__
+* `@beeware@fosstodon.org on Mastodon <https://fosstodon.org/@beeware>`__
 
 * `Discord <https://beeware.org/bee/chat/>`__
 

--- a/src/rubicon/objc/__init__.py
+++ b/src/rubicon/objc/__init__.py
@@ -54,7 +54,7 @@ from .api import (
     objc_rawmethod,
     py_from_ns,
 )
-from .runtime import SEL, send_message, send_super
+from .runtime import SEL, objc_block, objc_id, send_message, send_super
 from .types import (
     CFIndex,
     CFRange,
@@ -133,8 +133,10 @@ __all__ = [
     ObjCProtocol,
     at,
     ns_from_py,
+    objc_block,
     objc_classmethod,
     objc_const,
+    objc_id,
     objc_ivar,
     objc_method,
     objc_property,

--- a/src/rubicon/objc/api.py
+++ b/src/rubicon/objc/api.py
@@ -2207,7 +2207,7 @@ class ObjCBlock:
         # match the type of the argument that was actually provided. The first argument
         # to invoke is the block being invoked, so we can ignore that type hint.
         for i, argtype in enumerate(self.invoke_argtypes[1:]):
-            if hasattr(argtype, "__anonymous__"):
+            if getattr(argtype, "__anonymous__", False):
                 anon_fields = [f[1] for f in argtype._fields_]
                 arg_fields = [f[1] for f in args[i]._fields_]
                 if anon_fields != arg_fields:

--- a/src/rubicon/objc/types.py
+++ b/src/rubicon/objc/types.py
@@ -259,7 +259,7 @@ def _create_structish_type_for_encoding(encoding, *, base):
     # itself are typed correctly. Also annotate the structure with an `__anonymous__`
     # marker so that we can easily identify anonymous structures.
     py_name = "_Anonymous" if name is None else name.decode("utf-8")
-    structish_type = type(py_name, (base,), {"__anonymous__": True})
+    structish_type = type(py_name, (base,), {"__anonymous__": name is None})
     # Register the structish for its own encoding, so the same type is used in the future.
     register_encoding(encoding, structish_type)
     if name is not None:

--- a/src/rubicon/objc/types.py
+++ b/src/rubicon/objc/types.py
@@ -254,10 +254,12 @@ def _create_structish_type_for_encoding(encoding, *, base):
         # Anonymous structish, has no name.
         name = None
 
-    # Create the subclass. The _fields_ are not set yet, this is done later.
-    # The structish is already registered here, so that pointers to this structish type in itself are typed correctly.
+    # Create the subclass. The _fields_ are not set yet, this is done later. The
+    # structish is already registered here, so that pointers to this structish type in
+    # itself are typed correctly. Also annotate the structure with an `__anonymous__`
+    # marker so that we can easily identify anonymous structures.
     py_name = "_Anonymous" if name is None else name.decode("utf-8")
-    structish_type = type(py_name, (base,), {})
+    structish_type = type(py_name, (base,), {"__anonymous__": True})
     # Register the structish for its own encoding, so the same type is used in the future.
     register_encoding(encoding, structish_type)
     if name is not None:

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import platform
 import unittest
 from ctypes import Structure, c_int, c_void_p
 
@@ -9,31 +8,19 @@ from rubicon.objc.api import Block
 from rubicon.objc.runtime import objc_block
 
 
-def m1_block_failure(test):
-    # Properties/methods returning blocks currently fail on ARM hardware.
-    # See #225 for details
-    if platform.processor().startswith("arm"):
-        return unittest.expectedFailure(test)
-    else:
-        return test
-
-
 class BlockTests(unittest.TestCase):
-    @m1_block_failure
     def test_block_property_ctypes(self):
         BlockPropertyExample = ObjCClass("BlockPropertyExample")
         instance = BlockPropertyExample.alloc().init()
         result = ObjCBlock(instance.blockProperty, c_int, c_int, c_int)(1, 2)
         self.assertEqual(result, 3)
 
-    @m1_block_failure
     def test_block_property_pytypes(self):
         BlockPropertyExample = ObjCClass("BlockPropertyExample")
         instance = BlockPropertyExample.alloc().init()
         result = ObjCBlock(instance.blockProperty, int, int, int)(1, 2)
         self.assertEqual(result, 3)
 
-    @m1_block_failure
     def test_block_delegate_method_manual_ctypes(self):
         class DelegateManualC(NSObject):
             @objc_method
@@ -46,7 +33,6 @@ class BlockTests(unittest.TestCase):
         result = instance.blockExample()
         self.assertEqual(result, 5)
 
-    @m1_block_failure
     def test_block_delegate_method_manual_pytypes(self):
         class DelegateManualPY(NSObject):
             @objc_method
@@ -59,7 +45,6 @@ class BlockTests(unittest.TestCase):
         result = instance.blockExample()
         self.assertEqual(result, 5)
 
-    @m1_block_failure
     def test_block_delegate_auto(self):
         class DelegateAuto(NSObject):
             @objc_method
@@ -72,7 +57,6 @@ class BlockTests(unittest.TestCase):
         result = instance.blockExample()
         self.assertEqual(result, 9)
 
-    @m1_block_failure
     def test_block_delegate_auto_struct(self):
         class BlockStruct(Structure):
             _fields_ = [
@@ -143,7 +127,6 @@ class BlockTests(unittest.TestCase):
 
         self.assertEqual(values, [27])
 
-    @m1_block_failure
     def test_block_round_trip(self):
         BlockRoundTrip = ObjCClass("BlockRoundTrip")
         instance = BlockRoundTrip.alloc().init()
@@ -172,7 +155,6 @@ class BlockTests(unittest.TestCase):
         returned_block_2 = instance.roundTripNoArgs(block_2)
         self.assertEqual(returned_block_2(), 42)
 
-    @m1_block_failure
     def test_block_bound_method(self):
         """A bound method with type annotations can be wrapped in a block."""
 

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -57,6 +57,24 @@ class BlockTests(unittest.TestCase):
         result = instance.blockExample()
         self.assertEqual(result, 9)
 
+    def test_block_delegate_manual_struct(self):
+        class BlockStruct(Structure):
+            _fields_ = [
+                ("a", c_int),
+                ("b", c_int),
+            ]
+
+        class DelegateManualStruct(NSObject):
+            @objc_method
+            def structBlockMethod_(self, block: objc_block) -> int:
+                return ObjCBlock(block, int, BlockStruct)(BlockStruct(42, 43))
+
+        BlockObjectExample = ObjCClass("BlockObjectExample")
+        delegate = DelegateManualStruct.alloc().init()
+        instance = BlockObjectExample.alloc().initWithDelegate_(delegate)
+        result = instance.structBlockExample()
+        self.assertEqual(result, 85)
+
     def test_block_delegate_auto_struct(self):
         class BlockStruct(Structure):
             _fields_ = [


### PR DESCRIPTION
Fixes #225.

It appears that the fact that Blocks returned from Objective C APIs works at all is almost accidental.

When a block is returned from an ObjC API, an ObjCBlock instance is constructed, using the `ObjCBlockStruct` data provided for the block instance. This structure includes a pointer to an `invoke()` function, which is the function implementing the block.

The current codebase annotates the `restype` and `argtypes` onto the `invoke` method when the ObjCBlock is constructed. However, if you inspect the value of `invoke.restype` and `invoke.argtypes` immediately after they're assigned, you'll see that the assignment has had no effect - they return `c_void_p` and `(c_void_p,)` respectively (the default prototype for the invoke method, provided as the `_cfunc_type_block_invoke` declaration).

It appears that on x86_64 hardware, this doesn't matter. The `invoke` method can be invoked, ctypes doesn't complain, and the expected value is returned. However, on M1, ctypes raises TypeError exceptions; but because we're elbow-deep in block calls, that exception doesn't stop the application - it just results in a `c_void_p` "None" result from invoking the method. 

If instead we store the restype and argtypes, and apply them just before invoking the method (to a local copy of the invoke method), the invocation succeeds.

This reveals 2 additional bugs in the previous handling:
1. The invoke() method has an implied first argument that is the block itself. If an ObjCBlock is constructed with explicit `argtypes` (rather than inferring them from the block descriptor), this first argument isn't included in the argtypes of the invoke method.
2. If a block accepts a structure as an argument, the block descriptor may involve the use of an anonymous structure. When invoked with ctypes, the field pattern will match, but the structure class won't, causing ctypes to raise a TypeError. It is necessary to either cast the user-provided argument into the anonymous structure, or change the ctypes annotation to match the provided class. Since we needed to late-annotate the argtypes anyway, I've opted to use the second approach (including some light type checks).

This PR also exposes the `objc_id` and `objc_block` objects in the main `rubicon.objc` namespace; I've had frequent need to reference these types when using Rubicon as part of Toga, and it seemed odd that they weren't exposed in the core namespace.

This is an odd one for CI, because the old code also passed CI. The failure mode was only seen on M1 hardware, and until [Github adds M1 runners](https://github.com/github/roadmap/issues/528), we won't be able to do any automated validation of this. 

Huge thanks to @jeamland for his assistance nailing this one to the floor.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
