### PR TITLE
Bump pyupgrade from v3.10.1 to v3.11.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: isort
         additional_dependencies: [toml]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.10.1
+    rev: v3.11.0
     hooks:
       - id: pyupgrade
         args: [--py38-plus]

--- a/changes/367.misc.rst
+++ b/changes/367.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``pyupgrade`` was updated to its latest version.


### PR DESCRIPTION
Bumps `pre-commit` hook for `pyupgrade` from v3.10.1 to v3.11.0 and ran the update against the repo.