### PR TITLE
Add Ventura to the CI pool, and finalise Py3.12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        platform: [ "macOS-11", "macOS-12" ]
+        platform: [ "macOS-11", "macOS-12", "macOS-13" ]
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12-dev" ]
         include:
           - experimental: false

--- a/changes/373.misc.rst
+++ b/changes/373.misc.rst
@@ -1,0 +1,1 @@
+macOS 13 (Ventura) was added to the CI pool.

--- a/src/rubicon/objc/ctypes_patch.py
+++ b/src/rubicon/objc/ctypes_patch.py
@@ -19,7 +19,7 @@ import warnings
 # This module relies on the layout of a few internal Python and ctypes
 # structures. Because of this, it's possible (but not all that likely) that
 # things will break on newer/older Python versions.
-if sys.version_info < (3, 6) or sys.version_info >= (3, 12):
+if sys.version_info < (3, 6) or sys.version_info >= (3, 13):
     v = sys.version_info
     warnings.warn(
         "rubicon.objc.ctypes_patch has only been tested with Python 3.6 through 3.12. "


### PR DESCRIPTION
Github provides macOS 13 as a test target, so we should validate there.

Since we're testing on Py3.12, we can relax the import time warning on the ctypes patch as well.

Lastly, we can update the docstrings that refer to BPO to reference GitHub instead.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
