### PR TITLE
Bump isort from 5.12.0 to 5.13.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+    rev: 5.13.0
     hooks:
       - id: isort
         additional_dependencies: [toml]

--- a/changes/389.misc.rst
+++ b/changes/389.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``isort`` was updated to its latest version.


### PR DESCRIPTION
Bumps `pre-commit` hook for `isort` from 5.12.0 to 5.13.0 and ran the update against the repo.