### PR TITLE
Bump flake8 from 6.1.0 to 7.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     hooks:
     - id: black
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
       - id: flake8
   - repo: https://github.com/codespell-project/codespell

--- a/changes/398.misc.rst
+++ b/changes/398.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``flake8`` was updated to its latest version.


### PR DESCRIPTION
Bumps `pre-commit` hook for `flake8` from 6.1.0 to 7.0.0 and ran the update against the repo.