### PR TITLE
Bump black-pre-commit-mirror from 23.12.1 to 24.1.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: pyupgrade
         args: [--py38-plus]
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.12.1
+    rev: 24.1.1
     hooks:
     - id: black
   - repo: https://github.com/PyCQA/flake8

--- a/changes/404.misc.rst
+++ b/changes/404.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``black-pre-commit-mirror`` was updated to its latest version.

--- a/src/rubicon/objc/eventloop.py
+++ b/src/rubicon/objc/eventloop.py
@@ -267,7 +267,7 @@ class CFSocketHandle(events.Handle):
         libcf.CFSocketSetSocketFlags(
             self._cf_socket,
             kCFSocketAutomaticallyReenableReadCallBack
-            | kCFSocketAutomaticallyReenableWriteCallBack
+            | kCFSocketAutomaticallyReenableWriteCallBack,
             # # This extra flag is to ensure that CF doesn't (destructively,
             # # because destructively is the only way to do it) retrieve
             # # SO_ERROR

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -404,9 +404,11 @@ class RubiconTest(unittest.TestCase):
             + (
                 r"TypeError: 'float' object cannot be interpreted as an integer; argtypes: c_int"
                 if sys.version_info >= (3, 12)
-                else r"TypeError: wrong type; argtypes: c_int"
-                if sys.version_info >= (3, 10)
-                else r"<class 'TypeError'>: wrong type; argtypes: c_int"
+                else (
+                    r"TypeError: wrong type; argtypes: c_int"
+                    if sys.version_info >= (3, 10)
+                    else r"<class 'TypeError'>: wrong type; argtypes: c_int"
+                )
             ),
         ):
             obj.mutateIntFieldWithValue_(1.234)


### PR DESCRIPTION
Bumps `pre-commit` hook for `black-pre-commit-mirror` from 23.12.1 to 24.1.1 and ran the update against the repo.