### PR TITLE
Correct sphinx-autobuild dependency for Py3.8

### DIFF
--- a/changes/412.misc.rst
+++ b/changes/412.misc.rst
@@ -1,0 +1,1 @@
+Corrected sphinx-autobuild dependency for Python 3.8.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,9 @@ docs = [
     "sphinx == 7.1.2 ; python_version < '3.9'",
     "sphinx == 7.2.6 ; python_version >= '3.9'",
     "sphinx_tabs == 3.4.5",
-    "sphinx-autobuild == 2024.2.4",
+    # Sphinx 2024.2.4 deprecated support for Python 3.8
+    "sphinx-autobuild == 2021.3.14 ; python_version < '3.9'",
+    "sphinx-autobuild == 2024.2.4 ; python_version >= '3.9'",
     "sphinx-copybutton == 0.5.2",
     "sphinxcontrib-spelling == 8.0.0",
 ]


### PR DESCRIPTION
Adds a Python-version dependency pin for sphinx-auto build.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
