### PR TITLE
Fix `NSURL` examples in the documentation

### DIFF
--- a/changes/434.doc.rst
+++ b/changes/434.doc.rst
@@ -1,3 +1,0 @@
-The following points in the documentation (`tutorial-1.rst`) have been fixed:
-* The `absolute` variable, an instance of `NSURL`, has been fixed to be consistent.
-* The `print(NSURL)` example has been fixed to return only URL.

--- a/changes/434.doc.rst
+++ b/changes/434.doc.rst
@@ -1,0 +1,3 @@
+The following points in the documentation (`tutorial-1.rst`) have been fixed:
+* The `absolute` variable, an instance of `NSURL`, has been fixed to be consistent.
+* The `print(NSURL)` example has been fixed to return only URL.

--- a/changes/434.misc.rst
+++ b/changes/434.misc.rst
@@ -1,0 +1,1 @@
+Some typos in tutorial 1 were corrected.

--- a/docs/tutorial/tutorial-1.rst
+++ b/docs/tutorial/tutorial-1.rst
@@ -106,13 +106,13 @@ Python equivalents, ``__str__()`` and ``__repr__()``, respectively:
 .. code-block:: pycon
 
     >>> str(absolute)
-    'https://beeware.org/contributing/how/first-time/'
+    'https://beeware.org/contributing/'
 
     >>> repr(absolute)
     '<rubicon.objc.api.ObjCInstance 0x1114a3cf8: NSURL at 0x7fb2abdd0b20: https://beeware.org/contributing/>'
 
     >>> print(absolute)
-    <rubicon.objc.api.ObjCInstance 0x1114a3cf8: NSURL at 0x7fb2abdd0b20: https://beeware.org/contributing/>
+    https://beeware.org/contributing/
 
 Time to take over the world!
 ============================


### PR DESCRIPTION
The following points in the documentation ([Your first bridge](https://rubicon-objc.readthedocs.io/en/latest/tutorial/tutorial-1.html)) have been fixed:
* The `absolute` variable, an instance of `NSURL`, has been fixed to be consistent.
* The `print(absolute)` example has been fixed to return only URL.

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
