### PR TITLE
Fix the documentation (error message and venv path)

### DIFF
--- a/changes/435.misc.rst
+++ b/changes/435.misc.rst
@@ -1,0 +1,2 @@
+- Fix the error message in the documentation (`tutorial-2.rst`) to the current one.
+- Remove the `.sh` extension from the venv activation path in the documentation (`get-started.rst`).

--- a/changes/435.misc.rst
+++ b/changes/435.misc.rst
@@ -1,2 +1,1 @@
-- Fix the error message in the documentation (`tutorial-2.rst`) to the current one.
-- Remove the `.sh` extension from the venv activation path in the documentation (`get-started.rst`).
+Some typos in the documentation were corrected.

--- a/docs/how-to/get-started.rst
+++ b/docs/how-to/get-started.rst
@@ -7,7 +7,7 @@ To use Rubicon, create a new virtual environment, and install it:
 .. code-block:: console
 
     $ python3 -m venv venv
-    $ source venv/bin/activate.sh
+    $ source venv/bin/activate
     (venv) $ pip install rubicon-objc
 
 You're now ready to use Rubicon! Your next step is to work through the

--- a/docs/tutorial/tutorial-2.rst
+++ b/docs/tutorial/tutorial-2.rst
@@ -110,7 +110,7 @@ the same Python shell. If you try, you'll get an error:
     ...     pass
     Traceback (most recent call last)
     ...
-    RuntimeError: ObjC runtime already contains a registered class named 'Handler'.
+    RuntimeError: An Objective-C class named b'Handler' already exists
 
 You'll need to be careful (and sometimes, painfully verbose) when choosing class
 names.


### PR DESCRIPTION
- Fix the error message in the documentation (`tutorial-2.rst`) to the current one.
- Remove the `.sh` extension from the venv activation path in the documentation (`get-started.rst`).

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
