### PR TITLE
Minor documentation changes

### DIFF
--- a/changes/452.misc.rst
+++ b/changes/452.misc.rst
@@ -1,0 +1,1 @@
+Minor documentation changes.

--- a/docs/how-to/c-functions.rst
+++ b/docs/how-to/c-functions.rst
@@ -28,7 +28,7 @@ of standard C functions, this is the standard C library, ``libc``. Because this
 library is commonly used, Rubicon already loads it by default and exposes it in
 Python as :attr:`rubicon.objc.runtime.libc`.
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from rubicon.objc.runtime import libc
     >>> libc
@@ -43,7 +43,7 @@ Python as :attr:`rubicon.objc.runtime.libc`.
     To access a library that is not predefined by Rubicon, you can use the
     :func:`~rubicon.objc.runtime.load_library` function:
 
-    .. code-block:: python
+    .. code-block:: pycon
 
         >>> from rubicon.objc.runtime import load_library
         >>> libm = load_library("m")
@@ -52,7 +52,7 @@ Python as :attr:`rubicon.objc.runtime.libc`.
 
 C functions are accessed as attributes on their library:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> libc.puts
     <_FuncPtr object at 0x110178f20>
@@ -95,7 +95,7 @@ This means that ``puts`` returns an ``int`` and takes a single argument of type
 ``const char *`` (a pointer to one or more characters, i.e. a C string). This
 translates to the following Python ``ctypes`` code:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from ctypes import c_char_p, c_int
     >>> libc.puts.restype = c_int
@@ -110,7 +110,7 @@ to print out. ``ctypes`` automatically converts the byte string object to a
 needs to be a byte string (``bytes``), because C's ``char *`` strings are
 byte-based, unlike normal Python strings (``str``), which are Unicode-based.
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> res = libc.puts(b"Hello!")
     Hello!
@@ -227,7 +227,7 @@ instead of reading them directly as attributes of the library object, you use
 the ``in_dll`` method of the variable's *type*. (Every ``ctypes`` type has an
 ``in_dll`` method.)
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from ctypes import c_double
     >>> from rubicon.objc.runtime import Foundation
@@ -240,7 +240,7 @@ returns a ``ctypes`` data object that has the variable's type, in this case
 ``c_double``. To access the variable's actual value, you can use the data
 object's ``value`` attribute:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> NSFoundationVersionNumber.value
     1575.23
@@ -261,7 +261,7 @@ Foundation's ``<Foundation/NSMetadataAttribute.h>``:
 Because they are so common, Rubicon provides the convenience function
 ``objc_const`` specifically for accessing Objective-C object constants:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from rubicon.objc import objc_const
     >>> from rubicon.objc.runtime import Foundation

--- a/docs/how-to/protocols.rst
+++ b/docs/how-to/protocols.rst
@@ -12,7 +12,7 @@ Looking up a protocol
 Protocol objects can be looked up using the ``ObjCProtocol`` constructor,
 similar to how classes can be looked up using ``ObjCClass``:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> NSCopying = ObjCProtocol('NSCopying')
     >>> NSCopying
@@ -21,7 +21,7 @@ similar to how classes can be looked up using ``ObjCClass``:
 The ``isinstance`` function can be used to check whether an object conforms to
 a protocol:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> isinstance(NSObject.new(), NSCopying)
     False
@@ -63,7 +63,7 @@ like this:
 We can now use our class. The ``copy`` method (which uses our implemented
 ``copyWithZone:`` method) can also be used:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> ua = UserAccount.alloc().initWithUsername_emailAddress_(at('person'), at('person@example.com'))
     >>> ua
@@ -73,7 +73,7 @@ We can now use our class. The ``copy`` method (which uses our implemented
 
 And we can check that the class conforms to the protocol:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> isinstance(ua, NSCopying)
     True

--- a/docs/how-to/type-mapping.rst
+++ b/docs/how-to/type-mapping.rst
@@ -128,7 +128,7 @@ Strings
 :class:`str` objects - they can be sliced, concatenated, compared, etc. with
 other Objective-C and Python strings.
 
-.. code-block:: python
+.. code-block:: pycon
 
     # Call an Objective-C method that returns a string.
     # We're using NSBundle to give us a string version of a path
@@ -153,7 +153,7 @@ a method that does a specific type check for :class:`str`, you can use
 ``str(nsstring)`` to convert the :class:`~rubicon.objc.api.NSString` to
 :class:`str`:
 
-.. code-block:: python
+.. code-block:: pycon
 
     # Convert the Objective-C string to a Python string.
     >>> str(NSBundle.mainBundle.bundlePath)
@@ -164,7 +164,7 @@ Conversely, if you have a :class:`str`, and you specifically require a
 :func:`~rubicon.objc.api.at` function to convert the Python instance to an
 :class:`~rubicon.objc.api.NSString`.
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from rubicon.objc import at
     # Create a Python string
@@ -181,7 +181,7 @@ the return value from these methods, you should always use :class:`str` or
 :func:`~rubicon.objc.api.at` to ensure that you have the right kind of string
 for your needs.
 
-.. code-block:: python
+.. code-block:: pycon
 
     # Is the path comprised of all lowercase letters? (Hint: it isn't)
     >>> NSBundle.mainBundle.bundlePath.islower()
@@ -209,7 +209,7 @@ Lists
 sequence - they can be indexed, sliced, etc. and standard operations like
 :func:`len` and ``in`` are supported:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from rubicon.objc import NSArray
     >>> array = NSArray.arrayWithArray(list(range(4)))
@@ -241,7 +241,7 @@ sequence - they can be indexed, sliced, etc. and standard operations like
 :class:`~rubicon.objc.api.NSMutableArray` objects additionally support mutating
 operations, like item and slice assignment:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from rubicon.objc import NSMutableArray
     >>> mutarray = NSMutableArray.arrayWithArray(list(range(4)))
@@ -267,7 +267,7 @@ operations, like item and slice assignment:
 
 Sequence methods like ``index`` and ``pop`` are also supported:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> mutarray.index(7)
     3
@@ -287,7 +287,7 @@ Dictionaries
 mapping - their items can be accessed and standard operations like :func:`len`
 and ``in`` are supported:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from rubicon.objc import NSDictionary
     >>> d = objc.NSDictionary.dictionaryWithDictionary({"one": 1, "two": 2})
@@ -313,7 +313,7 @@ and ``in`` are supported:
 :class:`~rubicon.objc.api.NSMutableDictionary` objects additionally support
 mutating operations, like item assignment:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> md = objc.NSMutableDictionary.dictionaryWithDictionary({"one": 1, "two": 2})
     >>> md["three"] = 3
@@ -326,7 +326,7 @@ mutating operations, like item assignment:
 
 Mapping methods like ``keys`` and ``values`` are also supported:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> d.keys()
     <ObjCListInstance: __NSArrayI at 0x10b898a90: <__NSArrayI 0x7f86f8db6b70>(

--- a/docs/tutorial/tutorial-2.rst
+++ b/docs/tutorial/tutorial-2.rst
@@ -133,6 +133,7 @@ This option can also be enabled on a per-class basis by using the
 
 If this option is used, the Objective C class name will have a numeric suffix
 (e.g., `Handler_2`). The Python class name will be unchanged.
+
 What, no ``__init__()``?
 ========================
 


### PR DESCRIPTION
The following changes have been made to the documentation.
- Insert an appropriate line break in `tutorial-2.rst`
- Unify interactive mode code blocks to `pycon`

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
