### PR TITLE
Bump codespell from v2.2.6 to v2.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
     - id: codespell
       additional_dependencies:

--- a/changes/472.misc.rst
+++ b/changes/472.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``codespell`` was updated to its latest version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ docs = [
 skip = ".git,*.pdf,*.svg"
 # the way to make case sensitive skips of words etc
 ignore-regex = "\bNd\b"
-ignore-words-list = "re-use"
+ignore-words-list = "re-use,assertIn"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Bumps `pre-commit` hook for `codespell` from v2.2.6 to v2.3.0 and ran the update against the repo.