### PR TITLE
Remove pytest-tldr.

### DIFF
--- a/changes/473.bugfix.rst
+++ b/changes/473.bugfix.rst
@@ -1,0 +1,1 @@
+Protection was added against a potential race condition when loading methods defined on a superclass.

--- a/changes/473.misc.rst
+++ b/changes/473.misc.rst
@@ -1,0 +1,1 @@
+pytest-tldr was removed as a development requirement.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ dev = [
     "pre-commit == 3.5.0 ; python_version < '3.9'",
     "pre-commit == 3.7.0 ; python_version >= '3.9'",
     "pytest == 8.2.1",
-    "pytest-tldr == 0.2.5",
     "setuptools_scm == 8.1.0",
     "tox == 4.15.0",
 ]

--- a/src/rubicon/objc/api.py
+++ b/src/rubicon/objc/api.py
@@ -1629,11 +1629,13 @@ class ObjCClass(ObjCInstance, type):
 
         if self.superclass is not None:
             if self.superclass.methods_ptr is None:
-                self.superclass._load_methods()
+                with self.superclass.cache_lock:
+                    self.superclass._load_methods()
 
             # Prime this class' partials list with a list from the superclass.
             for first, superpartial in self.superclass.partial_methods.items():
-                partial = self.partial_methods[first] = ObjCPartialMethod(first)
+                partial = ObjCPartialMethod(first)
+                self.partial_methods[first] = partial
                 partial.methods.update(superpartial.methods)
 
         for i in range(methods_ptr_count.value):
@@ -1655,7 +1657,8 @@ class ObjCClass(ObjCInstance, type):
             try:
                 partial = self.partial_methods[first]
             except KeyError:
-                partial = self.partial_methods[first] = ObjCPartialMethod(first)
+                partial = ObjCPartialMethod(first)
+                self.partial_methods[first] = partial
 
             partial.methods[rest] = name
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1026,11 +1026,11 @@ class RubiconTest(unittest.TestCase):
         # ObjCBoundMethod
         self.assertRegex(
             repr(obj.init),
-            r"ObjCBoundMethod\(<ObjCMethod: init @16@0:8>, <NSObject: 0x[0-9a-f]{12}>\)",
+            r"ObjCBoundMethod\(<ObjCMethod: init @16@0:8>, <NSObject: 0x[0-9a-f]+>\)",
         )
         self.assertRegex(
             str(obj.init),
-            r"ObjCBoundMethod\(<ObjCMethod: init @16@0:8>, <NSObject: 0x[0-9a-f]{12}>\)",
+            r"ObjCBoundMethod\(<ObjCMethod: init @16@0:8>, <NSObject: 0x[0-9a-f]+>\)",
         )
 
         # ObjCPartialMethod


### PR DESCRIPTION
pytest-tldr is a cosmetic plugin that isn't requried for testing; it can be removed.

This reveals a weird Heisenbug in the handling of inherited classes, plus an issue with a test case pattern being overly restrictive for local testing. The Heisenbug is addressed by adding locking to superclass method loading. 

The original test failures on this PR don't have the extra locking; once locking is added, the tests pass.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
