### PR TITLE
Add explicit RTD version pin, and protect against Sphinx 8 deprecations

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3"
+    python: "3.12"
   jobs:
     pre_build:
       - tox -e docs-lint

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,6 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
+    # Docs are always built on Python 3.12. See also the tox config and contribution docs.
     python: "3.12"
   jobs:
     pre_build:

--- a/changes/496.doc.rst
+++ b/changes/496.doc.rst
@@ -1,0 +1,1 @@
+Building Rubicon ObjC's documentation now requires the use of Python 3.12.

--- a/changes/496.misc.rst
+++ b/changes/496.misc.rst
@@ -1,0 +1,1 @@
+The environment for RTD builds was pinned, and protection for Sphinx updates was added.

--- a/changes/496.misc.rst
+++ b/changes/496.misc.rst
@@ -1,1 +1,0 @@
-The environment for RTD builds was pinned, and protection for Sphinx updates was added.

--- a/docs/how-to/contribute-docs.rst
+++ b/docs/how-to/contribute-docs.rst
@@ -19,6 +19,8 @@ study the other index files for clues.
 Build documentation locally
 ---------------------------
 
+.. Docs are always built on Python 3.12. See also the RTD and tox config.
+
 To build the documentation locally, :ref:`set up a development environment
 <setup-dev-environment>`. However, you **must** have a Python 3.12 interpreter
 installed and available on your path (i.e., ``python3.12`` must start a Python

--- a/docs/how-to/contribute-docs.rst
+++ b/docs/how-to/contribute-docs.rst
@@ -20,7 +20,9 @@ Build documentation locally
 ---------------------------
 
 To build the documentation locally, :ref:`set up a development environment
-<setup-dev-environment>`.
+<setup-dev-environment>`. However, you **must** have a Python 3.12 interpreter
+installed and available on your path (i.e., ``python3.12`` must start a Python
+3.12 interpreter).
 
 You'll also need to install the Enchant spell checking library.
 Enchant can be installed using `Homebrew <https://brew.sh>`__:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,10 +59,12 @@ docs = [
     "furo == 2024.7.18",
     "pyenchant == 3.2.2",
     # Sphinx 7.2 deprecated support for Python 3.8
+    # Sphinx 8.0 deprecated support for Python 3.9
     "sphinx == 7.1.2 ; python_version < '3.9'",
+    "sphinx == 7.4.7 ; python_version == '3.9'",
     "sphinx == 7.4.7 ; python_version >= '3.9'",
     "sphinx_tabs == 3.4.5",
-    # Sphinx 2024.2.4 deprecated support for Python 3.8
+    # sphinx-autobuild 2024.2.4 deprecated support for Python 3.8
     "sphinx-autobuild == 2021.3.14 ; python_version < '3.9'",
     "sphinx-autobuild == 2024.4.16 ; python_version >= '3.9'",
     "sphinx-copybutton == 0.5.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dev = [
     "setuptools_scm == 8.1.0",
     "tox == 4.16.0",
 ]
-# Docs are always built on Py3.12; see RTD and tox config files,
+# Docs are always built on a specific Python version; see RTD and tox config files,
 # and the docs contribution guide.
 docs = [
     "furo == 2024.7.18",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,18 +55,14 @@ dev = [
     "setuptools_scm == 8.1.0",
     "tox == 4.16.0",
 ]
+# Docs are always built on Py3.12; see RTD and tox config files,
+# and the docs contribution guide.
 docs = [
     "furo == 2024.7.18",
     "pyenchant == 3.2.2",
-    # Sphinx 7.2 deprecated support for Python 3.8
-    # Sphinx 8.0 deprecated support for Python 3.9
-    "sphinx == 7.1.2 ; python_version < '3.9'",
-    "sphinx == 7.4.7 ; python_version == '3.9'",
-    "sphinx == 7.4.7 ; python_version >= '3.9'",
+    "sphinx == 7.4.7",
     "sphinx_tabs == 3.4.5",
-    # sphinx-autobuild 2024.2.4 deprecated support for Python 3.8
-    "sphinx-autobuild == 2021.3.14 ; python_version < '3.9'",
-    "sphinx-autobuild == 2024.4.16 ; python_version >= '3.9'",
+    "sphinx-autobuild == 2024.4.16",
     "sphinx-copybutton == 0.5.2",
     "sphinxcontrib-spelling == 8.0.0",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -42,16 +42,10 @@ commands =
 [docs]
 docs_dir = {tox_root}{/}docs
 build_dir = {[docs]docs_dir}{/}_build
-# replace when Sphinx>=7.3 and Python 3.8 is dropped:
-#  -T => --show-traceback
-#  -W => --fail-on-warning
-#  -b => --builder
-#  -v => --verbose
-#  -a => --write-all
-#  -E => --fresh-env
-sphinx_args = -T -W --keep-going --jobs auto
+sphinx_args = --show-traceback --fail-on-warning --keep-going --jobs auto
 
 [testenv:docs{,-lint,-all,-live,-live-src}]
+base_python = py312
 package = wheel
 wheel_build_env = .pkg
 change_dir = docs
@@ -62,9 +56,9 @@ passenv =
     #     export PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.2.dylib
     PYENCHANT_LIBRARY_PATH
 commands =
-    !lint-!all-!live : python -m sphinx {[docs]sphinx_args} {posargs} -b html {[docs]docs_dir} {[docs]build_dir}{/}html
-    lint : python -m sphinx {[docs]sphinx_args} {posargs} -b spelling {[docs]docs_dir} {[docs]build_dir}{/}spell
-    lint : python -m sphinx {[docs]sphinx_args} {posargs} -b linkcheck {[docs]docs_dir} {[docs]build_dir}{/}links
-    all  : python -m sphinx {[docs]sphinx_args} {posargs} -v -a -E -b html {[docs]docs_dir} {[docs]build_dir}{/}html
-    live-!src : sphinx-autobuild {[docs]sphinx_args} {posargs} -b html {[docs]docs_dir} {[docs]build_dir}{/}live
-    live-src  : sphinx-autobuild {[docs]sphinx_args} {posargs} -a -E --watch {tox_root}{/}src{/}rubicon{/}objc -b html {[docs]docs_dir} {[docs]build_dir}{/}live
+    !lint-!all-!live : python -m sphinx {[docs]sphinx_args} {posargs} --builder html {[docs]docs_dir} {[docs]build_dir}{/}html
+    lint : python -m sphinx {[docs]sphinx_args} {posargs} --builder spelling {[docs]docs_dir} {[docs]build_dir}{/}spell
+    lint : python -m sphinx {[docs]sphinx_args} {posargs} --builder linkcheck {[docs]docs_dir} {[docs]build_dir}{/}links
+    all  : python -m sphinx {[docs]sphinx_args} {posargs} --verbose --write-all --fresh-env --builder html {[docs]docs_dir} {[docs]build_dir}{/}html
+    live-!src : sphinx-autobuild {[docs]sphinx_args} {posargs} --builder html {[docs]docs_dir} {[docs]build_dir}{/}live
+    live-src  : sphinx-autobuild {[docs]sphinx_args} {posargs} --write-all --fresh-env --watch {tox_root}{/}src{/}rubicon{/}objc --builder html {[docs]docs_dir} {[docs]build_dir}{/}live

--- a/tox.ini
+++ b/tox.ini
@@ -45,6 +45,7 @@ build_dir = {[docs]docs_dir}{/}_build
 sphinx_args = --show-traceback --fail-on-warning --keep-going --jobs auto
 
 [testenv:docs{,-lint,-all,-live,-live-src}]
+# Docs are always built on Python 3.12. See also the RTD config and contribution docs.
 base_python = py312
 # give sphinx-autobuild time to shutdown http server
 suicide_timeout = 1

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,6 @@ base_python = py312
 suicide_timeout = 1
 package = wheel
 wheel_build_env = .pkg
-change_dir = docs
 extras = docs
 passenv =
     # On macOS M1, you need to manually set the location of the PyEnchant

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,8 @@ sphinx_args = --show-traceback --fail-on-warning --keep-going --jobs auto
 
 [testenv:docs{,-lint,-all,-live,-live-src}]
 base_python = py312
+# give sphinx-autobuild time to shutdown http server
+suicide_timeout = 1
 package = wheel
 wheel_build_env = .pkg
 change_dir = docs


### PR DESCRIPTION
To ensure a consistent and repeatable build environment, use a hard version pin on the RTD environment.

Also adds a pin to Sphinx on Python 3.9, as Sphinx 8 deprecates Python 3.9 support.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
