### PR TITLE
Support Python 3.14 and remove event loop's support for child watchers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,12 @@ jobs:
           # M1 runners
           "macos-14"
         ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13-dev" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13-dev", "3.14-dev" ]
         include:
           - experimental: false
           - python-version: "3.13-dev"
+            experimental: true
+          - python-version: "3.14-dev"
             experimental: true
 
         exclude:

--- a/changes/498.feature.rst
+++ b/changes/498.feature.rst
@@ -1,0 +1,1 @@
+Support for Python 3.14 was added.

--- a/changes/498.removal.rst
+++ b/changes/498.removal.rst
@@ -1,0 +1,1 @@
+For Python 3.14 and beyond, the event loop's support for child watchers was removed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
 ]

--- a/src/rubicon/objc/ctypes_patch.py
+++ b/src/rubicon/objc/ctypes_patch.py
@@ -21,10 +21,10 @@ import warnings
 # This module relies on the layout of a few internal Python and ctypes
 # structures. Because of this, it's possible (but not all that likely) that
 # things will break on newer/older Python versions.
-if sys.version_info < (3, 6) or sys.version_info >= (3, 14):
+if sys.version_info < (3, 6) or sys.version_info >= (3, 15):
     v = sys.version_info
     warnings.warn(
-        "rubicon.objc.ctypes_patch has only been tested with Python 3.6 through 3.13. "
+        "rubicon.objc.ctypes_patch has only been tested with Python 3.6 through 3.14. "
         f"You are using Python {v.major}.{v.minor}.{v.micro}. Most likely things will "
         "work properly, but you may experience crashes if Python's internals have "
         "changed significantly."

--- a/src/rubicon/objc/eventloop.py
+++ b/src/rubicon/objc/eventloop.py
@@ -1,10 +1,10 @@
 """PEP 3156 event loop based on CoreFoundation."""
 
 import contextvars
+import sys
 import threading
 from asyncio import (
     DefaultEventLoopPolicy,
-    SafeChildWatcher,
     coroutines,
     events,
     tasks,
@@ -15,6 +15,9 @@ from ctypes import CFUNCTYPE, POINTER, Structure, c_double, c_int, c_ulong, c_vo
 from .api import ObjCClass, objc_const
 from .runtime import load_library, objc_id
 from .types import CFIndex
+
+if sys.version_info < (3, 14):
+    from asyncio import SafeChildWatcher
 
 __all__ = [
     "EventLoopPolicy",
@@ -702,23 +705,30 @@ class EventLoopPolicy(events.AbstractEventLoopPolicy):
                 if threading.current_thread() == threading.main_thread():
                     self._watcher.attach_loop(self._default_loop)
 
-    def get_child_watcher(self):
-        """Get the watcher for child processes.
+    if sys.version_info < (3, 14):
 
-        If not yet set, a :class:`~asyncio.SafeChildWatcher` object is
-        automatically created.
-        """
-        if self._watcher is None:
-            self._init_watcher()
+        def get_child_watcher(self):
+            """Get the watcher for child processes.
 
-        return self._watcher
+            If not yet set, a :class:`~asyncio.SafeChildWatcher` object is
+            automatically created.
 
-    def set_child_watcher(self, watcher):
-        """Set the watcher for child processes."""
-        if self._watcher is not None:
-            self._watcher.close()
+            REMOVED: Child watcher support was obsoleted in Python 3.14.
+            """
+            if self._watcher is None:
+                self._init_watcher()
 
-        self._watcher = watcher
+            return self._watcher
+
+        def set_child_watcher(self, watcher):
+            """Set the watcher for child processes.
+
+            REMOVED: Child watcher support was obsoleted in Python 3.14.
+            """
+            if self._watcher is not None:
+                self._watcher.close()
+
+            self._watcher = watcher
 
 
 class CFLifecycle:

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ extend-ignore =
     E203,
 
 [tox]
-envlist = towncrier-check,pre-commit,docs{,-lint,-all},py{38,39,310,311,312,313}
+envlist = towncrier-check,pre-commit,docs{,-lint,-all},py{38,39,310,311,312,313,314}
 skip_missing_interpreters = true
 
 [testenv:pre-commit]
@@ -21,7 +21,7 @@ wheel_build_env = .pkg
 extras = dev
 commands = pre-commit run --all-files --show-diff-on-failure --color=always
 
-[testenv:py{,38,39,310,311,312,313}]
+[testenv:py{,38,39,310,311,312,313,314}]
 package = wheel
 wheel_build_env = .pkg
 depends = pre-commit


### PR DESCRIPTION
## Changes
- Closes #497
- Adds support for Python 3.14

## Notes
- Jumped the gun a bit...they've only added 3.14 for linux so far...

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct