### PR TITLE
Bump flake8 from 7.1.0 to 7.1.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     hooks:
     - id: black
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.0
+    rev: 7.1.1
     hooks:
       - id: flake8
   - repo: https://github.com/codespell-project/codespell

--- a/changes/500.misc.rst
+++ b/changes/500.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``flake8`` was updated to its latest version.


### PR DESCRIPTION
Bumps `pre-commit` hook for `flake8` from 7.1.0 to 7.1.1 and ran the update against the repo.