### PR TITLE
Add support for Python 3.14; drop support for 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
       uses: actions/setup-python@v5.2.0
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
 
     - name: Get packages
       uses: actions/download-artifact@v4.1.8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,28 +54,27 @@ jobs:
     name: Unit tests
     needs: [ pre-commit, towncrier, package ]
     runs-on: ${{ matrix.platform }}
-    continue-on-error: ${{ matrix.experimental }}
+    continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       fail-fast: false
       matrix:
         platform: [
           # X86-64 runners
-          "macos-12", "macos-13",
+          "macos-13",
           # M1 runners
-          "macos-14"
+          "macos-14", "macos-15"
         ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13-dev" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
         include:
-          - experimental: false
-          - python-version: "3.13-dev"
+          - python-version: "3.14"
             experimental: true
 
         exclude:
-          # actions/setup-python doesn't provide Python3.8 or 3.9 for M1.
+          # actions/setup-python doesn't provide Python 3.9 for M1.
           - platform: "macos-14"
-            python-version : "3.8"
+            python-version : "3.9"
 
-          - platform: "macos-14"
+          - platform: "macos-15"
             python-version : "3.9"
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     name: Unit tests
     needs: [ pre-commit, towncrier, package ]
     runs-on: ${{ matrix.platform }}
-    continue-on-error: ${{ matrix.experimental || false }}
+    continue-on-error: false
     strategy:
       fail-fast: false
       matrix:
@@ -65,10 +65,6 @@ jobs:
           "macos-14", "macos-15"
         ]
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
-        include:
-          - python-version: "3.14"
-            experimental: true
-
         exclude:
           # actions/setup-python doesn't provide Python 3.9 for M1.
           - platform: "macos-14"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     rev: v3.18.0
     hooks:
       - id: pyupgrade
-        args: [--py38-plus]
+        args: [--py39-plus]
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.10.0
     hooks:

--- a/changes/529.feature.rst
+++ b/changes/529.feature.rst
@@ -1,0 +1,1 @@
+Support for Python 3.14 was added.

--- a/changes/529.removal.rst
+++ b/changes/529.removal.rst
@@ -1,0 +1,1 @@
+Python 3.8 is no longer a supported platform.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = ["version"]
 name = "rubicon-objc"
 description = "A bridge between an Objective C runtime environment and Python."
 readme = "README.rst"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 license.text = "New BSD"
 authors = [
     {name="Russell Keith-Magee", email="russell@keith-magee.com"},
@@ -29,12 +29,12 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Objective C",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
 ]
@@ -48,9 +48,7 @@ Source = "https://github.com/beeware/rubicon-objc"
 
 [project.optional-dependencies]
 dev = [
-    # Pre-commit 3.6.0 deprecated support for Python 3.8
-    "pre-commit == 3.5.0 ; python_version < '3.9'",
-    "pre-commit == 4.0.1 ; python_version >= '3.9'",
+    "pre-commit == 4.0.1",
     "pytest == 8.3.3",
     "setuptools_scm == 8.1.0",
     "tox == 4.21.2",

--- a/src/rubicon/objc/ctypes_patch.py
+++ b/src/rubicon/objc/ctypes_patch.py
@@ -21,10 +21,10 @@ import warnings
 # This module relies on the layout of a few internal Python and ctypes
 # structures. Because of this, it's possible (but not all that likely) that
 # things will break on newer/older Python versions.
-if sys.version_info < (3, 6) or sys.version_info >= (3, 14):
+if sys.version_info < (3, 6) or sys.version_info >= (3, 15):
     v = sys.version_info
     warnings.warn(
-        "rubicon.objc.ctypes_patch has only been tested with Python 3.6 through 3.13. "
+        "rubicon.objc.ctypes_patch has only been tested with Python 3.6 through 3.15. "
         f"You are using Python {v.major}.{v.minor}.{v.micro}. Most likely things will "
         "work properly, but you may experience crashes if Python's internals have "
         "changed significantly."

--- a/src/rubicon/objc/eventloop.py
+++ b/src/rubicon/objc/eventloop.py
@@ -1,10 +1,10 @@
 """PEP 3156 event loop based on CoreFoundation."""
 
 import contextvars
+import sys
 import threading
 from asyncio import (
     DefaultEventLoopPolicy,
-    SafeChildWatcher,
     coroutines,
     events,
     tasks,
@@ -15,6 +15,9 @@ from ctypes import CFUNCTYPE, POINTER, Structure, c_double, c_int, c_ulong, c_vo
 from .api import ObjCClass, objc_const
 from .runtime import load_library, objc_id
 from .types import CFIndex
+
+if sys.version_info < (3, 14):
+    from asyncio import SafeChildWatcher
 
 __all__ = [
     "EventLoopPolicy",
@@ -695,30 +698,39 @@ class EventLoopPolicy(events.AbstractEventLoopPolicy):
         loop._policy = self
         return loop
 
-    def _init_watcher(self):
-        with events._lock:
-            if self._watcher is None:  # pragma: no branch
-                self._watcher = SafeChildWatcher()
-                if threading.current_thread() == threading.main_thread():
-                    self._watcher.attach_loop(self._default_loop)
+    if sys.version_info < (3, 14):
 
-    def get_child_watcher(self):
-        """Get the watcher for child processes.
+        def _init_watcher(self):
+            with events._lock:
+                if self._watcher is None:  # pragma: no branch
+                    self._watcher = SafeChildWatcher()
+                    if threading.current_thread() == threading.main_thread():
+                        self._watcher.attach_loop(self._default_loop)
 
-        If not yet set, a :class:`~asyncio.SafeChildWatcher` object is
-        automatically created.
-        """
-        if self._watcher is None:
-            self._init_watcher()
+        def get_child_watcher(self):
+            """Get the watcher for child processes.
 
-        return self._watcher
+            If not yet set, a :class:`~asyncio.SafeChildWatcher` object is
+            automatically created.
 
-    def set_child_watcher(self, watcher):
-        """Set the watcher for child processes."""
-        if self._watcher is not None:
-            self._watcher.close()
+            .. note::
+                Child watcher support was removed in Python 3.14
+            """
+            if self._watcher is None:
+                self._init_watcher()
 
-        self._watcher = watcher
+            return self._watcher
+
+        def set_child_watcher(self, watcher):
+            """Set the watcher for child processes.
+
+            .. note::
+                Child watcher support was removed in Python 3.14
+            """
+            if self._watcher is not None:
+                self._watcher.close()
+
+            self._watcher = watcher
 
 
 class CFLifecycle:

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ extend-ignore =
     E203,
 
 [tox]
-envlist = towncrier-check,pre-commit,docs{,-lint,-all},py{38,39,310,311,312,313}
+envlist = towncrier-check,pre-commit,docs{,-lint,-all},py{39,310,311,312,313,314}
 skip_missing_interpreters = true
 
 [testenv:pre-commit]
@@ -21,7 +21,7 @@ wheel_build_env = .pkg
 extras = dev
 commands = pre-commit run --all-files --show-diff-on-failure --color=always
 
-[testenv:py{,38,39,310,311,312,313}]
+[testenv:py{,39,310,311,312,313,314}]
 package = wheel
 wheel_build_env = .pkg
 depends = pre-commit


### PR DESCRIPTION
Python 3.8 is EOL; Python 3.14.0a0 has now been released. Update project requirements and CI to reflect this.

CI has also been updated to remove the use of the macOS-12 runner, as these are being removed in early December. macOS-15 runners have been added.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
