### PR TITLE
Force cache eviction when instance classes don't match.

### DIFF
--- a/changes/539.bugfix.rst
+++ b/changes/539.bugfix.rst
@@ -1,0 +1,1 @@
+An edge case of the instance cache has been fixed. This edge case would cause collection types (such as NSMutableDictionary) to *not* have their Python helper wrappers applied.


### PR DESCRIPTION
If a cache hit is found for a object pointer, check the underlying ObjC class name *and* the class instance. If *either* are a mismatch, report a cache miss. This ensures that collection types always have their Python wrappers applied, even if they are originally created (and cached) as a base ObjCInstance.

I haven't added a test for this because I haven't been able to find a way to reproduce the issue programmatically - it depends upon cache eviction behaviour, and the only place I've seen this problem occur is via beeware/toga-chart#191.

Fixes #539.
Fixes beeware/toga-chart#191.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
