### PR TITLE
Simplify recursion in ObjCClass method loading

### DIFF
--- a/changes/547.misc.rst
+++ b/changes/547.misc.rst
@@ -1,0 +1,1 @@
+Simplify ObjCClass method loading logic.

--- a/src/rubicon/objc/api.py
+++ b/src/rubicon/objc/api.py
@@ -1382,8 +1382,8 @@ class ObjCClass(ObjCInstance, type):
         new_attrs = {
             "name": objc_class_name,
             "methods_ptr": None,
-            # Mapping of name -> method pointer. Populated on first attribute access,
-            # does not contain methods from superclasses.
+            # Mapping of name -> method pointer. Populated on first attribute access
+            # with all methods of this class but **not** its superclasses.
             "instance_method_ptrs": {},
             # Cache of ObjCMethod instance keyed by selector name. Cache misses are
             # looked up on instance_method_ptrs for this class and its superclasses.
@@ -1392,9 +1392,9 @@ class ObjCClass(ObjCInstance, type):
             "instance_properties": {},
             # Explicitly declared properties
             "forced_properties": set(),
-            # Cache of ObjCPartialMethod instances keyed by first keyword of the
-            # selector name. Cache misses are looked up on instance_method_ptrs for this
-            # class and its superclasses.
+            # ObjCPartialMethod instances keyed by first keyword of the selector name.
+            # Populated on first attribute access with all methods of this class and its
+            # superclasses. Updated on misses, e.g., when the class hierarchy changes.
             "partial_methods": {},
             # A re-entrant thread lock moderating access to the ObjCClass
             # method/property cache. This ensures that only one thread populates


### PR DESCRIPTION
This PR simplifies and documents the recursive approach to method loading for an ObjCClass:

1. Document for `instance_method_ptrs`, `instance_methods`, and `partial_methods` what they contain and when they are populated.
2. Accommodate changes to class hierarchy during init.
3. Limit recursive method loading to `ObjCClass._load_methods` only.

I still want to test this with toga to see if there are any edge cases which are not covered by Rubicon's test suite.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
