### PR TITLE
Bump codespell from v2.3.0 to v2.4.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.0
     hooks:
     - id: codespell
       additional_dependencies:

--- a/changes/554.misc.rst
+++ b/changes/554.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``codespell`` was updated to its latest version.

--- a/docs/background/releases.rst
+++ b/docs/background/releases.rst
@@ -190,7 +190,7 @@ Bugfixes
 * Background threads will no longer lock up on iOS when an asyncio event loop is
   in use. (`#228 <https://github.com/beeware/rubicon-objc/issues/228>`__)
 * The ``ObjCInstance`` cache no longer returns a stale wrapper objects if a memory
-  address is re-used by the Objective C runtime. (`#249
+  address is reused by the Objective C runtime. (`#249
   <https://github.com/beeware/rubicon-objc/issues/249>`__)
 * It is now safe to open an asyncio event loop on a secondary thread. Previously
   this would work, but would intermittently fail with a segfault when then loop

--- a/docs/tutorial/tutorial-2.rst
+++ b/docs/tutorial/tutorial-2.rst
@@ -115,7 +115,7 @@ the same Python shell. If you try, you'll get an error:
 You'll need to be careful (and sometimes, painfully verbose) when choosing class
 names.
 
-To allow a class name to be re-used, you can set the class variable
+To allow a class name to be reused, you can set the class variable
 :attr:`~rubicon.objc.api.ObjCClass.auto_rename` to ``True``. This option enables
 automatic renaming of the Objective C class if a naming collision is detected:
 


### PR DESCRIPTION
Bumps `pre-commit` hook for `codespell` from v2.3.0 to v2.4.0 and ran the update against the repo.