### PR TITLE
Bump codespell from v2.4.0 to v2.4.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.0
+    rev: v2.4.1
     hooks:
     - id: codespell
       additional_dependencies:

--- a/changes/559.misc.rst
+++ b/changes/559.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``codespell`` was updated to its latest version.


### PR DESCRIPTION
Bumps `pre-commit` hook for `codespell` from v2.4.0 to v2.4.1 and ran the update against the repo.