### PR TITLE
Bump ruff-pre-commit from v0.11.10 to v0.12.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.10
+    rev: v0.12.1
     hooks:
       - id: ruff-format
       - id: ruff-check

--- a/changes/606.misc.rst
+++ b/changes/606.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``ruff-pre-commit`` was updated to its latest version.


### PR DESCRIPTION
Bumps `pre-commit` hook for `ruff-pre-commit` from v0.11.10 to v0.12.1 and ran the update against the repo.