### PR TITLE
Add Docformatter pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,17 @@ repos:
       - id: check-docstring-first
       - id: end-of-file-fixer
       - id: trailing-whitespace
+  - repo: https://github.com/PyCQA/docformatter
+    rev: v1.7.7
+    hooks:
+      - id: docformatter
+        args: [--in-place, --black]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.4
     hooks:
       - id: ruff-format
       - id: ruff-check
+        args: [ --fix ]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:

--- a/src/rubicon/objc/api.py
+++ b/src/rubicon/objc/api.py
@@ -97,9 +97,13 @@ _RETURNS_RETAINED_FAMILIES = {"init", "alloc", "new", "copy", "mutableCopy"}
 
 
 def get_method_family(method_name: str) -> str:
-    """Returns the method family from the method name. See
-    https://clang.llvm.org/docs/AutomaticReferenceCounting.html#method-families for
-    documentation on method families and corresponding selector names."""
+    """Returns the method family from the method name.
+
+    See
+    https://clang.llvm.org/docs/AutomaticReferenceCounting.html#method-families
+    for
+    documentation on method families and corresponding selector names.
+    """
     first_component = method_name.lstrip("_").split(":")[0]
     for family in _RETURNS_RETAINED_FAMILIES:
         if first_component.startswith(family):
@@ -150,8 +154,8 @@ def encoding_from_annotation(f, offset=1):
 
 
 class ObjCMethod:
-    """An unbound Objective-C method. This is Rubicon's high-level equivalent
-    of :class:`~rubicon.objc.runtime.Method`.
+    """An unbound Objective-C method. This is Rubicon's high-level equivalent of
+    :class:`~rubicon.objc.runtime.Method`.
 
     :class:`ObjCMethod` objects normally don't need to be used directly. To call
     a method on an Objective-C object, you should use the method call syntax
@@ -168,8 +172,8 @@ class ObjCMethod:
     """
 
     def __init__(self, method):
-        """The constructor takes a :class:`~rubicon.objc.runtime.Method`
-        object, whose information is used to create an :class:`ObjCMethod`.
+        """The constructor takes a :class:`~rubicon.objc.runtime.Method` object, whose
+        information is used to create an :class:`ObjCMethod`.
 
         This can be used to call or introspect a
         :class:`~rubicon.objc.runtime.Method` pointer received from the
@@ -348,9 +352,8 @@ class ObjCPartialMethod:
 
 
 class ObjCBoundMethod:
-    """This represents an Objective-C method (an IMP) which has been bound to
-    some id which will be passed as the first parameter to the method.
-    """
+    """This represents an Objective-C method (an IMP) which has been bound to some id
+    which will be passed as the first parameter to the method."""
 
     def __init__(self, method, receiver):
         """Initialize with a method and ObjCInstance or ObjCClass object."""
@@ -369,9 +372,8 @@ class ObjCBoundMethod:
 
 
 def convert_method_arguments(encoding, args):
-    """Used to convert Objective-C method arguments to Python values before
-    passing them on to the Python-defined method.
-    """
+    """Used to convert Objective-C method arguments to Python values before passing them
+    on to the Python-defined method."""
     new_args = []
     for e, a in zip(encoding[3:], args):
         if issubclass(e, (objc_id, ObjCInstance)):
@@ -382,8 +384,8 @@ def convert_method_arguments(encoding, args):
 
 
 class objc_method:
-    """Exposes the decorated method as an Objective-C instance method in a
-    custom class or protocol.
+    """Exposes the decorated method as an Objective-C instance method in a custom class
+    or protocol.
 
     In a custom Objective-C class, decorating a method with :func:`@objc_method
     <objc_method>` makes it available to Objective-C: a corresponding
@@ -431,12 +433,12 @@ class objc_method:
 
 
 class objc_classmethod:
-    """Exposes the decorated method as an Objective-C class method in a custom
-    class or protocol.
+    """Exposes the decorated method as an Objective-C class method in a custom class or
+    protocol.
 
-    This decorator behaves exactly like :func:`@objc_method <objc_method>`,
-    except that the decorated method becomes a class method, so it is exposed
-    on the Objective-C class rather than its instances.
+    This decorator behaves exactly like :func:`@objc_method <objc_method>`, except that
+    the decorated method becomes a class method, so it is exposed on the Objective-C
+    class rather than its instances.
     """
 
     def __init__(self, py_method):
@@ -673,8 +675,8 @@ class objc_property:
 
 
 class objc_rawmethod:
-    """Exposes the decorated method as an Objective-C instance method in a
-    custom class, with fewer convenience features than :func:`objc_method`.
+    """Exposes the decorated method as an Objective-C instance method in a custom class,
+    with fewer convenience features than :func:`objc_method`.
 
     This decorator behaves similarly to :func:`@objc_method <objc_method>`.
     However, unlike with :func:`objc_method`, no automatic conversions are
@@ -716,8 +718,8 @@ _type_for_objcclass_map = {}
 
 
 def type_for_objcclass(objcclass):
-    """Look up the :class:`ObjCInstance` subclass used to represent instances
-    of the given Objective-C class in Python.
+    """Look up the :class:`ObjCInstance` subclass used to represent instances of the
+    given Objective-C class in Python.
 
     If the exact Objective-C class is not registered, each superclass is also
     checked, defaulting to :class:`ObjCInstance` if none of the classes in the
@@ -752,8 +754,8 @@ def type_for_objcclass(objcclass):
 
 
 def register_type_for_objcclass(pytype, objcclass):
-    """Register a conversion from an Objective-C class to an
-    :class:`ObjCInstance` subclass.
+    """Register a conversion from an Objective-C class to an :class:`ObjCInstance`
+    subclass.
 
     After a call of this function, when Rubicon wraps an Objective-C object that
     is an instance of ``objcclass`` (or a subclass), the Python object will have
@@ -776,8 +778,8 @@ def register_type_for_objcclass(pytype, objcclass):
 
 
 def unregister_type_for_objcclass(objcclass):
-    """Unregister a conversion from an Objective-C class to an
-    :class:`ObjCInstance` subclass.
+    """Unregister a conversion from an Objective-C class to an :class:`ObjCInstance`
+    subclass.
 
     .. warning::
 
@@ -795,8 +797,8 @@ def unregister_type_for_objcclass(objcclass):
 
 
 def get_type_for_objcclass_map():
-    """Get a copy of all currently registered :class:`ObjCInstance` subclasses
-    as a mapping.
+    """Get a copy of all currently registered :class:`ObjCInstance` subclasses as a
+    mapping.
 
     Keys are Objective-C class addresses as :class:`int`\\s.
     """
@@ -874,9 +876,9 @@ class ObjCInstance:
     def __new__(
         cls, object_ptr, _name=None, _bases=None, _ns=None, _implicitly_owned=False
     ):
-        """The constructor accepts an :class:`~rubicon.objc.runtime.objc_id` or
-        anything that can be cast to one, such as a :class:`~ctypes.c_void_p`,
-        or an existing :class:`ObjCInstance`.
+        """The constructor accepts an :class:`~rubicon.objc.runtime.objc_id` or anything
+        that can be cast to one, such as a :class:`~ctypes.c_void_p`, or an existing
+        :class:`ObjCInstance`.
 
         :class:`ObjCInstance` objects are cached --- this means that for every
         Objective-C object there can be at most one :class:`ObjCInstance` object
@@ -1004,16 +1006,16 @@ class ObjCInstance:
         return repr(self)
 
     def __repr__(self):
-        """Get a debugging representation of ``self``, which includes the
-        Objective-C object's class and ``debugDescription``."""
+        """Get a debugging representation of ``self``, which includes the Objective-C
+        object's class and ``debugDescription``."""
         return (
             f"<{type(self).__qualname__}: {self.objc_class.name} at "
             f"{id(self):#x}: {self.debugDescription}>"
         )
 
     def __getattr__(self, name):
-        """Allows accessing Objective-C properties and methods using Python
-        attribute syntax.
+        """Allows accessing Objective-C properties and methods using Python attribute
+        syntax.
 
         If ``self`` has a Python attribute with the given name, its value is
         returned.
@@ -1184,8 +1186,8 @@ class ObjCClass(ObjCInstance, type):
 
     @property
     def superclass(self):
-        """The superclass of this class, or ``None`` if this is a root class
-        (such as :class:`NSObject`)."""
+        """The superclass of this class, or ``None`` if this is a root class (such as
+        :class:`NSObject`)."""
 
         super_ptr = libobjc.class_getSuperclass(self)
         if super_ptr.value is None:
@@ -1338,9 +1340,9 @@ class ObjCClass(ObjCInstance, type):
         protocols=(),
         auto_rename=None,
     ):
-        """The constructor accepts either the name of an Objective-C class to
-        look up (as :class:`str` or :class:`bytes`), or a pointer to an existing
-        class object (in any form accepted by :class:`ObjCInstance`).
+        """The constructor accepts either the name of an Objective-C class to look up
+        (as :class:`str` or :class:`bytes`), or a pointer to an existing class object
+        (in any form accepted by :class:`ObjCInstance`).
 
         If given a pointer, it must refer to an Objective-C class; pointers to
         other objects are not accepted. (Use :class:`ObjCInstance` to wrap a
@@ -1443,9 +1445,9 @@ class ObjCClass(ObjCInstance, type):
         super().__init__(*args)
 
     def _cache_method(self, name):
-        """Returns a python representation of the named instance method, either
-        by looking it up in the cached list of methods or by searching for and
-        creating a new method object."""
+        """Returns a python representation of the named instance method, either by
+        looking it up in the cached list of methods or by searching for and creating a
+        new method object."""
         with self.cache_lock:
             try:
                 # Try to return an existing cached method for the name
@@ -1514,11 +1516,9 @@ class ObjCClass(ObjCInstance, type):
         return methods
 
     def _cache_property_accessor(self, name):
-        """Returns a python representation of an accessor for the named
-        property.
+        """Returns a python representation of an accessor for the named property.
 
-        Existence of a property is done by looking for the write
-        selector (set<Name>:).
+        Existence of a property is done by looking for the write selector (set<Name>:).
         """
         with self.cache_lock:
             try:
@@ -1531,11 +1531,9 @@ class ObjCClass(ObjCInstance, type):
         return None
 
     def _cache_property_mutator(self, name):
-        """Returns a python representation of an accessor for the named
-        property.
+        """Returns a python representation of an accessor for the named property.
 
-        Existence of a property is done by looking for the write
-        selector (set<Name>:).
+        Existence of a property is done by looking for the write selector (set<Name>:).
         """
         with self.cache_lock:
             try:
@@ -1690,10 +1688,9 @@ class ObjCMetaClass(ObjCClass):
     """
 
     def __new__(cls, name_or_ptr):
-        """The constructor accepts either the name of an Objective-C metaclass
-        to look up (as :class:`str` or :class:`bytes`), or a pointer to an
-        existing metaclass object (in any form accepted by
-        :class:`ObjCInstance`).
+        """The constructor accepts either the name of an Objective-C metaclass to look
+        up (as :class:`str` or :class:`bytes`), or a pointer to an existing metaclass
+        object (in any form accepted by :class:`ObjCInstance`).
 
         If given a pointer, it must refer to an Objective-C metaclass; pointers
         to other objects are not accepted. (Use :class:`ObjCInstance` to wrap a
@@ -1738,8 +1735,7 @@ Protocol = ObjCClass("Protocol")
 
 
 def py_from_ns(nsobj):
-    """Convert a Foundation object into an equivalent Python object if
-    possible.
+    """Convert a Foundation object into an equivalent Python object if possible.
 
     Currently supported types:
 
@@ -1801,8 +1797,8 @@ def py_from_ns(nsobj):
 
 
 def ns_from_py(pyobj):
-    """Convert a Python object into an equivalent Foundation object. The
-    returned object is autoreleased.
+    """Convert a Python object into an equivalent Foundation object. The returned object
+    is autoreleased.
 
     This function is also available under the name :func:`at`, because its
     functionality is very similar to that of the Objective-C ``@`` operator and
@@ -1896,10 +1892,9 @@ class ObjCProtocol(ObjCInstance):
     automatically if a protocol with the same name is already exists."""
 
     def __new__(cls, name_or_ptr, bases=None, ns=None, auto_rename=None):
-        """The constructor accepts either the name of an Objective-C protocol
-        to look up (as :class:`str` or :class:`bytes`), or a pointer to an
-        existing protocol object (in any form accepted by
-        :class:`ObjCInstance`).
+        """The constructor accepts either the name of an Objective-C protocol to look up
+        (as :class:`str` or :class:`bytes`), or a pointer to an existing protocol object
+        (in any form accepted by :class:`ObjCInstance`).
 
         If given a pointer, it must refer to an Objective-C protocol; pointers
         to other objects are not accepted. (Use :class:`ObjCInstance` to wrap a
@@ -2090,9 +2085,9 @@ def objc_const(dll, name):
     """Create an :class:`ObjCInstance` from a global pointer variable in a
     :class:`~ctypes.CDLL`.
 
-    This function is most commonly used to access constant object pointers
-    defined by a library/framework, such as `NSCocoaErrorDomain
-    <https://developer.apple.com/documentation/foundation/nscocoaerrordomain?language=objc>`__.
+    This function is most commonly used to access constant object pointers defined by a
+    library/framework, such as
+    `NSCocoaErrorDomain <https://developer.apple.com/documentation/foundation/nscocoaerrordomain?language=objc>`__.
     """
 
     return ObjCInstance(objc_id.in_dll(dll, name))
@@ -2188,8 +2183,7 @@ class ObjCBlock:
 
     def __init__(self, pointer, restype=AUTO, *argtypes):
         """The constructor takes a block object, which can be either an
-        :class:`ObjCInstance`, or a raw :class:`~rubicon.objc.runtime.objc_id`
-        pointer.
+        :class:`ObjCInstance`, or a raw :class:`~rubicon.objc.runtime.objc_id` pointer.
 
         .. note::
 
@@ -2308,8 +2302,7 @@ NOTHING = object()
 
 
 class Block:
-    """A wrapper that exposes a Python callable object to Objective-C as a
-    block.
+    """A wrapper that exposes a Python callable object to Objective-C as a block.
 
     .. note::
 

--- a/src/rubicon/objc/collections.py
+++ b/src/rubicon/objc/collections.py
@@ -27,17 +27,16 @@ NSBackwardsSearch = 4
 
 @for_objcclass(NSString)
 class ObjCStrInstance(ObjCInstance):
-    """Provides Pythonic operations on NSString objects that mimic those of
-    Python's str.
+    """Provides Pythonic operations on NSString objects that mimic those of Python's
+    str.
 
-    Note that str objects consist of Unicode code points, whereas
-    NSString objects consist of UTF-16 code units. These are not
-    equivalent for code points greater than U+FFFF. For performance and
-    simplicity, ObjCStrInstance objects behave as sequences of UTF-16
-    code units, like NSString. (Individual UTF-16 code units are
-    represented as Python str objects of length 1.) If you need to
-    access or iterate over code points instead of UTF-16 code units, use
-    str(nsstring) to convert the NSString to a Python str first.
+    Note that str objects consist of Unicode code points, whereas NSString objects
+    consist of UTF-16 code units. These are not equivalent for code points greater than
+    U+FFFF. For performance and simplicity, ObjCStrInstance objects behave as sequences
+    of UTF-16 code units, like NSString. (Individual UTF-16 code units are represented
+    as Python str objects of length 1.) If you need to access or iterate over code
+    points instead of UTF-16 code units, use str(nsstring) to convert the NSString to a
+    Python str first.
     """
 
     def __str__(self):
@@ -68,10 +67,9 @@ class ObjCStrInstance(ObjCInstance):
     def _compare(self, other, want):
         """Helper method used to implement the comparison operators.
 
-        If other is a str or NSString, it is compared to self, and True
-        or False is returned depending on whether the result is one of
-        the wanted values. If other is not a string, NotImplemented is
-        returned.
+        If other is a str or NSString, it is compared to self, and True or False is
+        returned depending on whether the result is one of the wanted values. If other
+        is not a string, NotImplemented is returned.
         """
 
         if isinstance(other, str):

--- a/src/rubicon/objc/ctypes_patch.py
+++ b/src/rubicon/objc/ctypes_patch.py
@@ -1,12 +1,12 @@
-"""This module provides a workaround to allow callback functions to return
-composite types (most importantly structs).
+"""This module provides a workaround to allow callback functions to return composite
+types (most importantly structs).
 
 Currently, ctypes callback functions (created by passing a Python callable to a
 CFUNCTYPE object) are only able to return what ctypes considers a "simple" type. This
 includes void (None), scalars (c_int, c_float, etc.), c_void_p, c_char_p, c_wchar_p, and
 py_object. Returning "composite" types (structs, unions, and non-"simple" pointers) is
-not possible. This issue has been reported on the Python bug tracker
-(https://github.com/python/cpython/issues/49960).
+not possible. This issue has been reported on the Python bug tracker (
+https://github.com/python/cpython/issues/49960).
 
 For pointers, the easiest workaround is to return a c_void_p instead of the correctly
 typed pointer, and to cast the value on both sides. For structs and unions there is no
@@ -150,13 +150,12 @@ if sys.version_info < (3, 13):
         return mappingproxyobject.from_address(id(proxy)).mapping
 
     def get_stgdict_of_type(tp):
-        """Return the given ctypes type's StgDict object. If the object's dict is
-        not a StgDict, an error is raised.
+        """Return the given ctypes type's StgDict object. If the object's dict is not a
+        StgDict, an error is raised.
 
-        This function is roughly equivalent to the PyType_stgdict function in the
-        ctypes source code. We cannot use that function directly, because it is not
-        part of CPython's public C API, and thus not accessible on some systems (see
-        #113).
+        This function is roughly equivalent to the PyType_stgdict function in the ctypes
+        source code. We cannot use that function directly, because it is not part of
+        CPython's public C API, and thus not accessible on some systems (see #113).
         """
 
         if not isinstance(tp, type):
@@ -209,8 +208,8 @@ else:
         """Return the given ctypes type's StgInfo object.
 
         This function is roughly equivalent to the PyStgInfo_FromType function in the
-        ctypes source code. We cannot use that function directly, because it is not
-        part of CPython's public C API, and thus not accessible).
+        ctypes source code. We cannot use that function directly, because it is not part
+        of CPython's public C API, and thus not accessible).
         """
         # Original code:
         #   if (!PyObject_IsInstance((PyObject *)type, (PyObject *)state->PyCType_Type))
@@ -244,13 +243,12 @@ ctypes.pythonapi.Py_IncRef.argtypes = [ctypes.POINTER(PyObject)]
 
 
 def make_callback_returnable(ctype):
-    """Modify the given ctypes type so it can be returned from a callback
-    function.
+    """Modify the given ctypes type so it can be returned from a callback function.
 
     This function may be used as a decorator on a struct/union declaration.
 
-    The method is idempotent; it only modifies the type the first time it
-    is invoked on a type.
+    The method is idempotent; it only modifies the type the first time it is invoked on
+    a type.
     """
     # The presence of the _rubicon_objc_ctypes_patch_getfunc attribute is a
     # sentinel for whether the type has been modified previously.

--- a/src/rubicon/objc/eventloop.py
+++ b/src/rubicon/objc/eventloop.py
@@ -269,9 +269,9 @@ class CFSocketHandle(events.Handle):
             callback(*args)
 
     def __init__(self, *, loop, fd):
-        """Register a file descriptor with the CFRunLoop, or modify its state
-        so that it's listening for both notifications (read and write) rather
-        than just one; used to implement add_reader and add_writer."""
+        """Register a file descriptor with the CFRunLoop, or modify its state so that
+        it's listening for both notifications (read and write) rather than just one;
+        used to implement add_reader and add_writer."""
         super().__init__(CFSocketCallback(self._cf_socket_callback), None, loop)
 
         # Retain a reference to the Handle
@@ -384,8 +384,8 @@ class CFEventLoop(unix_events.SelectorEventLoop):
     def add_reader(self, fd, callback, *args):
         """Add a reader callback.
 
-        Method is a direct call through to _add_reader to reflect an
-        internal implementation detail added in Python3.5.
+        Method is a direct call through to _add_reader to reflect an internal
+        implementation detail added in Python3.5.
         """
         self._add_reader(fd, callback, *args)
 
@@ -399,8 +399,8 @@ class CFEventLoop(unix_events.SelectorEventLoop):
     def remove_reader(self, fd):
         """Remove a reader callback.
 
-        Method is a direct call through to _remove_reader to reflect an
-        internal implementation detail added in Python3.5.
+        Method is a direct call through to _remove_reader to reflect an internal
+        implementation detail added in Python3.5.
         """
         self._remove_reader(fd)
 
@@ -416,8 +416,8 @@ class CFEventLoop(unix_events.SelectorEventLoop):
     def add_writer(self, fd, callback, *args):
         """Add a writer callback.
 
-        Method is a direct call through to _add_writer to reflect an
-        internal implementation detail added in Python3.5.
+        Method is a direct call through to _add_writer to reflect an internal
+        implementation detail added in Python3.5.
         """
         self._add_writer(fd, callback, *args)
 
@@ -431,8 +431,8 @@ class CFEventLoop(unix_events.SelectorEventLoop):
     def remove_writer(self, fd):
         """Remove a writer callback.
 
-        Method is a direct call through to _remove_writer to reflect an
-        internal implementation detail added in Python3.5.
+        Method is a direct call through to _remove_writer to reflect an internal
+        implementation detail added in Python3.5.
         """
         self._remove_writer(fd)
 
@@ -449,8 +449,7 @@ class CFEventLoop(unix_events.SelectorEventLoop):
         return self._running
 
     def run(self):
-        """Internal implementation of run using the CoreFoundation event
-        loop."""
+        """Internal implementation of run using the CoreFoundation event loop."""
         recursive = self.is_running()
         if (
             not recursive
@@ -522,10 +521,10 @@ class CFEventLoop(unix_events.SelectorEventLoop):
     def run_forever_cooperatively(self, lifecycle=None):
         """A non-blocking version of :meth:`run_forever`.
 
-        This may seem like nonsense; however, an iOS app is not expected to
-        invoke a blocking "main event loop" method. As a result, we need to
-        be able to *start* Python event loop handling, but then return control
-        to the main app to start the actual event loop.
+        This may seem like nonsense; however, an iOS app is not expected to invoke a
+        blocking "main event loop" method. As a result, we need to be able to *start*
+        Python event loop handling, but then return control to the main app to start the
+        actual event loop.
 
         The implementation is effectively all the parts of a call to
         :meth:`run_forever()`, but without any of the shutdown/cleanup logic.
@@ -615,17 +614,16 @@ class CFEventLoop(unix_events.SelectorEventLoop):
     def time(self):
         """Return the time according to the event loop's clock.
 
-        This is a float expressed in seconds since an epoch, but the
-        epoch, precision, accuracy and drift are unspecified and may
-        differ per event loop.
+        This is a float expressed in seconds since an epoch, but the epoch, precision,
+        accuracy and drift are unspecified and may differ per event loop.
         """
         return libcf.CFAbsoluteTimeGetCurrent()
 
     def stop(self):
         """Stop running the event loop.
 
-        Every callback already scheduled will still run.  This simply
-        informs run_forever to stop looping after a complete iteration.
+        Every callback already scheduled will still run.  This simply informs
+        run_forever to stop looping after a complete iteration.
         """
         super().stop()
         self._lifecycle.stop()
@@ -633,8 +631,8 @@ class CFEventLoop(unix_events.SelectorEventLoop):
     def close(self):
         """Close the event loop.
 
-        This clears the queues and shuts down the executor,
-        but does not wait for the executor to finish.
+        This clears the queues and shuts down the executor, but does not wait for the
+        executor to finish.
 
         The event loop must not be running.
         """
@@ -663,14 +661,13 @@ class CFEventLoop(unix_events.SelectorEventLoop):
     def _add_callback(self, handle):
         """Add a callback to be invoked ASAP.
 
-        The inherited behavior uses a self-pipe to wake up the event loop
-        in a thread-safe fashion, which causes the logic in run_once() to
-        empty the list of handlers that are awaiting invocation.
+        The inherited behavior uses a self-pipe to wake up the event loop in a thread-
+        safe fashion, which causes the logic in run_once() to empty the list of handlers
+        that are awaiting invocation.
 
-        CFEventLoop doesn't use run_once(), so adding handlers to
-        self._ready results in handlers that aren't invoked. Instead, we
-        create a 0-interval timer to invoke the callback as soon as
-        possible.
+        CFEventLoop doesn't use run_once(), so adding handlers to self._ready results in
+        handlers that aren't invoked. Instead, we create a 0-interval timer to invoke
+        the callback as soon as possible.
         """
         if handle._cancelled:
             return

--- a/src/rubicon/objc/runtime.py
+++ b/src/rubicon/objc/runtime.py
@@ -160,8 +160,8 @@ class SEL(c_void_p):
         return libobjc.sel_getName(self)
 
     def __new__(cls, init=None):
-        """The constructor can be called with a :class:`bytes` or :class:`str`
-        object to obtain a selector with that value.
+        """The constructor can be called with a :class:`bytes` or :class:`str` object to
+        obtain a selector with that value.
 
         (The normal arguments supported by :class:`~ctypes.c_void_p` are
         still accepted.)
@@ -495,12 +495,10 @@ try:
 except AttributeError:
 
     def object_isClass(obj):
-        """Return whether the given Objective-C object is a class (or a
-        metaclass).
+        """Return whether the given Objective-C object is a class (or a metaclass).
 
-        This is the emulated version of the object_isClass runtime
-        function, for systems older than OS X 10.10 or iOS 8, where the
-        real function doesn't exist yet.
+        This is the emulated version of the object_isClass runtime function, for systems
+        older than OS X 10.10 or iOS 8, where the real function doesn't exist yet.
         """
 
         return libobjc.class_isMetaClass(libobjc.object_getClass(obj))
@@ -663,8 +661,7 @@ def ensure_bytes(x):
 
 
 def get_class(name):
-    """Get the Objective-C class with the given name as a :class:`Class`
-    object.
+    """Get the Objective-C class with the given name as a :class:`Class` object.
 
     If no class with the given name is loaded, ``None`` is returned, and
     the Objective-C runtime will log a warning message.
@@ -723,8 +720,8 @@ _msg_send_cache = {}
 
 
 def _msg_send_for_types(restype, argtypes):
-    """Get the appropriate variant of ``objc_msgSend`` for calling a method
-    with the given return and argument types.
+    """Get the appropriate variant of ``objc_msgSend`` for calling a method with the
+    given return and argument types.
 
     :param restype: The return type of the method to be called.
     :param argtypes: The argument types of the method to be called, excluding
@@ -883,8 +880,8 @@ def send_super(
     varargs=None,
     _allow_dealloc=False,
 ):
-    """In the context of the given class, call a superclass method on the
-    receiver with the given selector and arguments.
+    """In the context of the given class, call a superclass method on the receiver with
+    the given selector and arguments.
 
     This is the equivalent of an Objective-C method call like
     ``[super sel:args]`` in the class ``cls``.
@@ -1151,16 +1148,16 @@ def set_ivar(obj, varname, value, weak=False):
 
 @contextmanager
 def autoreleasepool():
-    """A context manager that has the same effect as a @autoreleasepool block
-    in Objective-C.
+    """A context manager that has the same effect as a @autoreleasepool block in
+    Objective-C.
 
-    Any objects that are autoreleased within the context will receive a release
-    message when exiting the context. When running an event loop, AppKit will
-    create an autorelease pool at the beginning of each cycle of the event loop
-    and drain it at the end. You therefore do not need to use @autoreleasepool
-    blocks when running an event loop. However, they may be still be useful when
-    your code temporarily allocates large amounts of memory which you want to
-    explicitly free before the end of a cycle.
+    Any objects that are autoreleased within the context will receive a release message
+    when exiting the context. When running an event loop, AppKit will create an
+    autorelease pool at the beginning of each cycle of the event loop and drain it at
+    the end. You therefore do not need to use @autoreleasepool blocks when running an
+    event loop. However, they may be still be useful when your code temporarily
+    allocates large amounts of memory which you want to explicitly free before the end
+    of a cycle.
     """
     pool = libobjc.objc_autoreleasePoolPush()
 

--- a/src/rubicon/objc/types.py
+++ b/src/rubicon/objc/types.py
@@ -164,9 +164,8 @@ _encoding_for_ctype_map = {}
 def _end_of_encoding(encoding, start):
     """Find the end index of the encoding starting at index start.
 
-    The encoding is not validated very extensively. There are no
-    guarantees what happens for invalid encodings; an error may be
-    raised, or a bogus end index may be returned.
+    The encoding is not validated very extensively. There are no guarantees what happens
+    for invalid encodings; an error may be raised, or a bogus end index may be returned.
     """
 
     if start < 0 or start >= len(encoding):
@@ -238,9 +237,8 @@ def _end_of_encoding(encoding, start):
 def _create_structish_type_for_encoding(encoding, *, base):
     """Create a structish type from the given encoding.
 
-    ("structish" = "structure or union")
-    The base kwarg controls which base class is used. It should be either
-    ctypes.Structure or ctypes.Union.
+    ("structish" = "structure or union") The base kwarg controls which base class is
+    used. It should be either ctypes.Structure or ctypes.Union.
     """
 
     # Split name and fields.
@@ -406,8 +404,8 @@ def encoding_for_ctype(ctype):
 
 
 def register_preferred_encoding(encoding, ctype):
-    """Register a preferred conversion between an Objective-C type encoding and
-    a C type.
+    """Register a preferred conversion between an Objective-C type encoding and a C
+    type.
 
     "Preferred" means that any existing conversions in each direction are
     overwritten with the new conversion. To register an encoding without
@@ -419,8 +417,8 @@ def register_preferred_encoding(encoding, ctype):
 
 
 def with_preferred_encoding(encoding):
-    """Register a preferred conversion between an Objective-C type encoding and
-    the decorated C type.
+    """Register a preferred conversion between an Objective-C type encoding and the
+    decorated C type.
 
     This is equivalent to calling :func:`register_preferred_encoding` on the
     decorated C type.
@@ -434,8 +432,8 @@ def with_preferred_encoding(encoding):
 
 
 def register_encoding(encoding, ctype):
-    """Register an additional conversion between an Objective-C type encoding
-    and a C type.
+    """Register an additional conversion between an Objective-C type encoding and a C
+    type.
 
     "Additional" means that any existing conversions in either direction are
     *not* overwritten with the new conversion. To register an encoding and
@@ -447,8 +445,8 @@ def register_encoding(encoding, ctype):
 
 
 def with_encoding(encoding):
-    """Register an additional conversion between an Objective-C type encoding
-    and the decorated C type.
+    """Register an additional conversion between an Objective-C type encoding and the
+    decorated C type.
 
     This is equivalent to calling :func:`register_encoding` on the
     decorated C type.
@@ -462,8 +460,8 @@ def with_encoding(encoding):
 
 
 def unregister_encoding(encoding):
-    """Unregister the conversion from an Objective-C type encoding to its
-    corresponding C type.
+    """Unregister the conversion from an Objective-C type encoding to its corresponding
+    C type.
 
     Note that this does not remove any conversions in the other direction (from
     a C type to this encoding). These conversions may be replaced with
@@ -493,8 +491,8 @@ def unregister_encoding_all(encoding):
 
 
 def unregister_ctype(ctype):
-    """Unregister the conversion from a C type to its corresponding
-    Objective-C type encoding.
+    """Unregister the conversion from a C type to its corresponding Objective-C type
+    encoding.
 
     Note that this does not remove any conversions in the other direction (from
     an encoding to this C type). These conversions may be replaced with
@@ -508,8 +506,8 @@ def unregister_ctype(ctype):
 
 
 def unregister_ctype_all(ctype):
-    """Unregister all conversions between a C type and all corresponding
-    Objective-C type encodings.
+    """Unregister all conversions between a C type and all corresponding Objective-C
+    type encodings.
 
     All conversions from any type encoding to this C type are removed
     recursively using :func:`unregister_encoding_all`.
@@ -524,15 +522,15 @@ def unregister_ctype_all(ctype):
 
 
 def get_ctype_for_encoding_map():
-    """Get a copy of all currently registered encoding-to-C type conversions
-    as a map."""
+    """Get a copy of all currently registered encoding-to-C type conversions as a
+    map."""
 
     return dict(_ctype_for_encoding_map)
 
 
 def get_encoding_for_ctype_map():
-    """Get a copy of all currently registered C type-to-encoding conversions
-    as a map."""
+    """Get a copy of all currently registered C type-to-encoding conversions as a
+    map."""
 
     return dict(_encoding_for_ctype_map)
 
@@ -540,12 +538,12 @@ def get_encoding_for_ctype_map():
 def split_method_encoding(encoding):
     """Split a method signature encoding into a sequence of type encodings.
 
-    The first type encoding represents the return type, all remaining type
-    encodings represent the argument types.
+    The first type encoding represents the return type, all remaining type encodings
+    represent the argument types.
 
-    If there are any numbers after a type encoding, they are ignored. On
-    PowerPC, these numbers indicated each argument/return value's offset on the
-    stack. These numbers are meaningless on modern architectures.
+    If there are any numbers after a type encoding, they are ignored. On PowerPC, these
+    numbers indicated each argument/return value's offset on the stack. These numbers
+    are meaningless on modern architectures.
     """
 
     encodings = []
@@ -615,8 +613,8 @@ def _array_for_sequence(seq, array_type):
 
 
 def compound_value_for_sequence(seq, tp):
-    """Create a C structure or array of type ``tp``, initialized with values
-    from ``seq``.
+    """Create a C structure or array of type ``tp``, initialized with values from
+    ``seq``.
 
     If ``tp`` is a :class:`~ctypes.Structure` type, the newly created
     structure's fields are initialized in declaration order with the values from
@@ -743,8 +741,7 @@ register_preferred_encoding(_PyObjectEncoding, py_object)
 @with_encoding(b"^{?}")
 @with_encoding(b"^(?)")
 class UnknownPointer(c_void_p):
-    """Placeholder for the "unknown pointer" types ``^?``, ``^{?}`` and
-    ``^(?)``.
+    """Placeholder for the "unknown pointer" types ``^?``, ``^{?}`` and ``^(?)``.
 
     Not to be confused with a ``^v`` void pointer.
 

--- a/tests/test_NSString.py
+++ b/tests/test_NSString.py
@@ -138,7 +138,7 @@ class NSStringTests(unittest.TestCase):
                     self.assertNotIn(ns_needle, ns_haystack)
 
     def test_nsstring_len(self):
-        """len() works on NSString."""
+        """``len()`` works on NSString."""
 
         for pystr in type(self).TEST_STRINGS:
             with self.subTest(pystr=pystr):

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -182,8 +182,8 @@ class BlockTests(unittest.TestCase):
         self.assertEqual(returned_block(8, 9), 17)
 
     def test_block_round_trip_no_arguments(self):
-        """A block that takes no arguments can be created with both ways of
-        specifying types."""
+        """A block that takes no arguments can be created with both ways of specifying
+        types."""
 
         BlockRoundTrip = ObjCClass("BlockRoundTrip")
         instance = BlockRoundTrip.alloc().init()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -223,8 +223,7 @@ class RubiconTest(unittest.TestCase):
         self.assertIsInstance(Example, ObjCClass)
 
     def test_objcinstance_can_produce_objcmetaclass(self):
-        """Creating an ObjCInstance for a metaclass pointer gives an
-        ObjCMetaClass."""
+        """Creating an ObjCInstance for a metaclass pointer gives an ObjCMetaClass."""
 
         examplemeta_ptr = libobjc.objc_getMetaClass(b"Example")
         ExampleMeta = ObjCInstance(examplemeta_ptr)
@@ -232,8 +231,7 @@ class RubiconTest(unittest.TestCase):
         self.assertIsInstance(ExampleMeta, ObjCMetaClass)
 
     def test_objcclass_can_produce_objcmetaclass(self):
-        """Creating an ObjCClass for a metaclass pointer gives an
-        ObjCMetaclass."""
+        """Creating an ObjCClass for a metaclass pointer gives an ObjCMetaclass."""
 
         examplemeta_ptr = libobjc.objc_getMetaClass(b"Example")
         ExampleMeta = ObjCClass(examplemeta_ptr)
@@ -241,8 +239,7 @@ class RubiconTest(unittest.TestCase):
         self.assertIsInstance(ExampleMeta, ObjCMetaClass)
 
     def test_objcinstance_can_produce_objcprotocol(self):
-        """Creating an ObjCInstance for a protocol pointer gives an
-        ObjCProtocol."""
+        """Creating an ObjCInstance for a protocol pointer gives an ObjCProtocol."""
 
         example_protocol_ptr = libobjc.objc_getProtocol(b"ExampleProtocol")
         ExampleProtocol = ObjCInstance(example_protocol_ptr)
@@ -312,7 +309,7 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(DerivedProtocol.protocols, (BaseProtocolOne, BaseProtocolTwo))
 
     def test_objcclass_instancecheck(self):
-        """isinstance works with an ObjCClass as the second argument."""
+        """``isinstance()`` works with an ObjCClass as the second argument."""
         self.assertIsInstance(NSObject.new(), NSObject)
         self.assertIsInstance(at(""), NSString)
         self.assertIsInstance(at(""), NSObject)
@@ -324,7 +321,7 @@ class RubiconTest(unittest.TestCase):
         self.assertNotIsInstance(NSArray.array, NSString)
 
     def test_objcclass_subclasscheck(self):
-        """issubclass works with an ObjCClass as the second argument."""
+        """``issubclass()`` works with an ObjCClass as the second argument."""
         self.assertTrue(issubclass(NSObject, NSObject))
         self.assertTrue(issubclass(NSString, NSObject))
         self.assertTrue(issubclass(NSObject.objc_class, NSObject))
@@ -343,7 +340,7 @@ class RubiconTest(unittest.TestCase):
             issubclass(NSObjectProtocol, NSObject)
 
     def test_objcprotocol_instancecheck(self):
-        """isinstance works with an ObjCProtocol as the second argument."""
+        """``isinstance()`` works with an ObjCProtocol as the second argument."""
 
         NSCoding = ObjCProtocol("NSCoding")
         NSSecureCoding = ObjCProtocol("NSSecureCoding")
@@ -355,7 +352,7 @@ class RubiconTest(unittest.TestCase):
         self.assertNotIsInstance(NSObject.new(), NSSecureCoding)
 
     def test_objcprotocol_subclasscheck(self):
-        """issubclass works with an ObjCProtocol as the second argument."""
+        """``issubclass()`` works with an ObjCProtocol as the second argument."""
         NSCopying = ObjCProtocol("NSCopying")
         NSCoding = ObjCProtocol("NSCoding")
         NSSecureCoding = ObjCProtocol("NSSecureCoding")
@@ -377,7 +374,7 @@ class RubiconTest(unittest.TestCase):
             issubclass(NSObject.new(), NSSecureCoding)
 
     def test_field(self):
-        """A field on an instance can be accessed and mutated"""
+        """A field on an instance can be accessed and mutated."""
 
         Example = ObjCClass("Example")
 
@@ -408,8 +405,8 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(obj.accessIntField(), 9999)
 
     def test_method_incorrect_argument_count(self):
-        """Attempting to call a method with an incorrect number of arguments
-        throws an exception."""
+        """Attempting to call a method with an incorrect number of arguments throws an
+        exception."""
 
         Example = ObjCClass("Example")
         obj = Example.alloc().init()
@@ -424,9 +421,8 @@ class RubiconTest(unittest.TestCase):
             obj.mutateIntFieldWithValue_(123, "extra argument")
 
     def test_method_incorrect_argument_type(self):
-        """
-        Attempting to call a method with the wrong type of argument throws an exception.
-        """
+        """Attempting to call a method with the wrong type of argument throws an
+        exception."""
 
         Example = ObjCClass("Example")
         obj = Example.alloc().init()
@@ -448,8 +444,8 @@ class RubiconTest(unittest.TestCase):
             obj.mutateIntFieldWithValue_(1.234)
 
     def test_method_incorrect_argument_count_send(self):
-        """Attempting to call a method with send_message with an incorrect
-        number of arguments throws an exception."""
+        """Attempting to call a method with send_message with an incorrect number of
+        arguments throws an exception."""
 
         Example = ObjCClass("Example")
         obj = Example.alloc().init()
@@ -562,8 +558,8 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(obj.baseIntField, 10)
 
     def test_send_super_incorrect_argument_count(self):
-        """Attempting to call a method with send_super with an incorrect number
-        of arguments throws an exception."""
+        """Attempting to call a method with send_super with an incorrect number of
+        arguments throws an exception."""
         SpecificExample = ObjCClass("SpecificExample")
 
         obj = SpecificExample.alloc().init()
@@ -613,7 +609,7 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(obj.accessBaseIntField(), 11)
 
     def test_static_field(self):
-        """A static field on a class can be accessed and mutated"""
+        """A static field on a class can be accessed and mutated."""
         Example = ObjCClass("Example")
 
         Example.mutateStaticBaseIntFieldWithValue_(1)
@@ -744,7 +740,7 @@ class RubiconTest(unittest.TestCase):
             Example.static_method_doesnt_exist()
 
     def test_polymorphic_constructor(self):
-        """Check that the right constructor is activated based on arguments used"""
+        """Check that the right constructor is activated based on arguments used."""
         Example = ObjCClass("Example")
 
         obj1 = Example.alloc().init()
@@ -765,7 +761,7 @@ class RubiconTest(unittest.TestCase):
             Example.alloc().initWithString_("Hello")
 
     def test_static_access_non_static(self):
-        """An instance field/method cannot be accessed from the static context"""
+        """An instance field/method cannot be accessed from the static context."""
         Example = ObjCClass("Example")
 
         obj = Example.alloc().init()
@@ -777,7 +773,7 @@ class RubiconTest(unittest.TestCase):
             obj.get_staticIntField()
 
     def test_non_static_access_static(self):
-        """A static field/method cannot be accessed from an instance context"""
+        """A static field/method cannot be accessed from an instance context."""
         Example = ObjCClass("Example")
 
         with self.assertRaises(AttributeError):
@@ -820,24 +816,21 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(obj.accessIntField(), MyEnum.value4.value)
 
     def test_string_return(self):
-        """If a method or field returns a string, you get a Python string back"""
+        """If a method or field returns a string, you get a Python string back."""
         Example = ObjCClass("Example")
         example = Example.alloc().init()
         self.assertEqual(example.toString(), "This is an ObjC Example object")
 
     def test_constant_string_return(self):
-        """
-        If a method or field returns a *constant* string, you get a Python string back
-        """
+        """If a method or field returns a *constant* string, you get a Python string
+        back."""
         Example = ObjCClass("Example")
         example = Example.alloc().init()
         self.assertEqual(example.smiley(), "%-)")
 
     def test_number_return(self):
-        """
-        If a method or field returns a NSNumber, it is not automatically converted
-        to a Python number.
-        """
+        """If a method or field returns a NSNumber, it is not automatically converted to
+        a Python number."""
         Example = ObjCClass("Example")
         example = Example.alloc().init()
 
@@ -952,10 +945,8 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(example.largeStruct().x, b"abcdefghijklmnop")
 
     def test_struct_return_send(self):
-        """
-        Methods returning structs of different sizes by value can be handled
-        when using send_message.
-        """
+        """Methods returning structs of different sizes by value can be handled when
+        using send_message."""
         Example = ObjCClass("Example")
         example = Example.alloc().init()
 
@@ -977,10 +968,8 @@ class RubiconTest(unittest.TestCase):
         )
 
     def test_object_return(self):
-        """
-        If a method or field returns an object, you get an instance of
-        that type returned
-        """
+        """If a method or field returns an object, you get an instance of that type
+        returned."""
         Example = ObjCClass("Example")
         example = Example.alloc().init()
 
@@ -1060,7 +1049,7 @@ class RubiconTest(unittest.TestCase):
             Example.overloaded(0, invalidArgument=0)
 
     def test_objcmethod_str_repr(self):
-        """Test ObjCMethod, ObjCPartialMethod, and ObjCBoundMethod str and repr"""
+        """Test ObjCMethod, ObjCPartialMethod, and ObjCBoundMethod str and repr."""
 
         obj = NSObject.new()
 
@@ -1109,8 +1098,8 @@ class RubiconTest(unittest.TestCase):
         )
 
     def test_objcinstance_str_repr_with_nil_descriptions(self):
-        """An ObjCInstance's str and repr work even if description and
-        debugDescription are nil."""
+        """An ObjCInstance's str and repr work even if description and debugDescription
+        are nil."""
 
         DescriptionTester = ObjCClass("DescriptionTester")
         tester = DescriptionTester.alloc().initWithDescriptionString(
@@ -1727,10 +1716,8 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(str(string_const), "Some global string constant")
 
     def test_interface_return_struct(self):
-        """
-        An ObjC protocol implementation that returns values by struct can
-        be defined in Python.
-        """
+        """An ObjC protocol implementation that returns values by struct can be defined
+        in Python."""
 
         results = {}
         Thing = ObjCClass("Thing")
@@ -1834,8 +1821,8 @@ class RubiconTest(unittest.TestCase):
             _ = thing.python_object_1
 
     def test_objcinstance_python_attribute_keep_alive(self):
-        """Python attributes on an ObjCInstance are kept even if the object
-        temporarily has no Python references."""
+        """Python attributes on an ObjCInstance are kept even if the object temporarily
+        has no Python references."""
 
         Example = ObjCClass("Example")
         example = Example.alloc().init()
@@ -1918,7 +1905,9 @@ class RubiconTest(unittest.TestCase):
 
     def test_objcinstance_returned_lifecycle(self):
         """An object is retained when creating an ObjCInstance for it without implicit
-        ownership. It is autoreleased when the ObjCInstance is garbage collected.
+        ownership.
+
+        It is autoreleased when the ObjCInstance is garbage collected.
         """
 
         def create_object():
@@ -1939,8 +1928,9 @@ class RubiconTest(unittest.TestCase):
 
     def test_objcinstance_alloc_init_lifecycle(self):
         """An object is not additionally retained when we create and initialize it
-        through an alloc().init() chain. It is autoreleased when the ObjCInstance is
-        garbage collected.
+        through an alloc().init() chain.
+
+        It is autoreleased when the ObjCInstance is garbage collected.
         """
 
         def create_object():
@@ -1950,7 +1940,9 @@ class RubiconTest(unittest.TestCase):
 
     def test_objcinstance_new_lifecycle(self):
         """An object is not additionally retained when we create and initialize it with
-        a new call. It is autoreleased when the ObjCInstance is garbage collected.
+        a new call.
+
+        It is autoreleased when the ObjCInstance is garbage collected.
         """
 
         def create_object():
@@ -1960,7 +1952,9 @@ class RubiconTest(unittest.TestCase):
 
     def test_objcinstance_copy_lifecycle(self):
         """An object is not additionally retained when we create and initialize it with
-        a copy call. It is autoreleased when the ObjCInstance is garbage collected.
+        a copy call.
+
+        It is autoreleased when the ObjCInstance is garbage collected.
         """
 
         def create_object():
@@ -1976,10 +1970,10 @@ class RubiconTest(unittest.TestCase):
         assert_lifecycle(self, create_object)
 
     def test_objcinstance_mutable_copy_lifecycle(self):
-        """
-        An object is not additionally retained when we create and initialize it with
-        a mutableCopy call. It is autoreleased when the ObjCInstance is garbage
-        collected.
+        """An object is not additionally retained when we create and initialize it with
+        a mutableCopy call.
+
+        It is autoreleased when the ObjCInstance is garbage collected.
         """
 
         def create_object():
@@ -2012,8 +2006,8 @@ class RubiconTest(unittest.TestCase):
         assert_lifecycle(self, create_object)
 
     def test_objcinstance_init_change_lifecycle(self):
-        """We do not leak memory if init returns a different object than it
-        received in alloc."""
+        """We do not leak memory if init returns a different object than it received in
+        alloc."""
 
         def create_object():
             with autoreleasepool():
@@ -2071,10 +2065,8 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(attr1.retainCount(), 1, "weak property value was released")
 
     def test_partial_with_override(self):
-        """
-        If one method in a partial is overridden, that doesn't impact lookup of
-        other partial targets
-        """
+        """If one method in a partial is overridden, that doesn't impact lookup of other
+        partial targets."""
         SpecificExample = ObjCClass("SpecificExample")
 
         obj = SpecificExample.alloc().init()
@@ -2088,10 +2080,8 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(obj.baseIntField, 2)
 
     def test_compatible_class_name_change(self):
-        """
-        If the class name changes in a compatible way, the wrapper isn't
-        recreated (#257)
-        """
+        """If the class name changes in a compatible way, the wrapper isn't recreated
+        (#257)"""
         Example = ObjCClass("Example")
 
         pre_init = Example.alloc()
@@ -2110,10 +2100,8 @@ class RubiconTest(unittest.TestCase):
         assert id(pre_init) == id(post_init)
 
     def test_threaded_wrapper_creation(self):
-        """
-        If 2 threads try to create a wrapper for the same object, only 1
-        wrapper is created (#251)
-        """
+        """If 2 threads try to create a wrapper for the same object, only 1 wrapper is
+        created (#251)"""
         # Create an ObjC instance, and keep a track of the memory address
         Example = ObjCClass("Example")
         obj = Example.alloc().init()
@@ -2152,8 +2140,8 @@ class RubiconTest(unittest.TestCase):
             self.assertEqual(id(wrappers[0]), id(wrappers[1]))
 
     def test_threaded_method_cache(self):
-        """If 2 threads try to access a method on the same object,
-        there's no race condition populating the cache (#252)"""
+        """If 2 threads try to access a method on the same object, there's no race
+        condition populating the cache (#252)"""
         # Wrap a class with lots of methods, and create the instance
         Example = ObjCClass("Example")
         obj = Example.alloc().init()
@@ -2185,8 +2173,8 @@ class RubiconTest(unittest.TestCase):
             thread.join()
 
     def test_threaded_accessor_cache(self):
-        """If 2 threads try to access an accessor on the same object,
-        there's no race condition populating the cache (#252)"""
+        """If 2 threads try to access an accessor on the same object, there's no race
+        condition populating the cache (#252)"""
         # Wrap a class with lots of methods, and create the instance
         Example = ObjCClass("Example")
         obj = Example.alloc().init()
@@ -2218,8 +2206,8 @@ class RubiconTest(unittest.TestCase):
             thread.join()
 
     def test_threaded_mutator_cache(self):
-        """If 2 threads try to access a mutator on the same object,
-        there's no race condition populating the cache (#252)"""
+        """If 2 threads try to access a mutator on the same object, there's no race
+        condition populating the cache (#252)"""
         # Wrap a class with lots of methods, and create the instance
         Example = ObjCClass("Example")
         obj = Example.alloc().init()

--- a/tests/test_ctypes_patch.py
+++ b/tests/test_ctypes_patch.py
@@ -105,8 +105,7 @@ class CtypesPatchTest(unittest.TestCase):
             self.assertEqual(struct.ham, 123)
 
     def test_patched_type_returned_often(self):
-        """Returning a patched type very often works properly without crashing
-        anything.
+        """Returning a patched type very often works properly without crashing anything.
 
         This checks that bpo-36880 is either fixed or worked around.
         """


### PR DESCRIPTION
Adds a docformatter pre-commit check, and adds a `--fix` argument to ruff usage.

This gets Rubicon-objc and Briefcase pre-commit configurations to parity.

Fixes #610.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
