### PR TITLE
Bump ruff-pre-commit from v0.12.7 to v0.12.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: docformatter
         args: [--in-place, --black]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.7
+    rev: v0.12.8
     hooks:
       - id: ruff-format
       - id: ruff-check

--- a/changes/630.misc.rst
+++ b/changes/630.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``ruff-pre-commit`` was updated to its latest version.


### PR DESCRIPTION
Bumps `pre-commit` hook for `ruff-pre-commit` from v0.12.7 to v0.12.8 and ran the update against the repo.