### PR TITLE
Bump docformatter from v1.7.7 to v1.7.8-rc1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.7
+    rev: v1.7.8-rc1
     hooks:
       - id: docformatter
         args: [--in-place, --black]

--- a/changes/631.misc.rst
+++ b/changes/631.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``docformatter`` was updated to its latest version.

--- a/src/rubicon/objc/api.py
+++ b/src/rubicon/objc/api.py
@@ -153,8 +153,8 @@ def encoding_from_annotation(f, offset=1):
 
 
 class ObjCMethod:
-    """An unbound Objective-C method. This is Rubicon's high-level equivalent of
-    :class:`~rubicon.objc.runtime.Method`.
+    """An unbound Objective-C method. :class:`~rubicon.objc.runtime.Method`. This is
+    Rubicon's high-level equivalent of.
 
     :class:`ObjCMethod` objects normally don't need to be used directly. To call
     a method on an Objective-C object, you should use the method call syntax
@@ -223,7 +223,6 @@ class ObjCMethod:
         --- the method's :attr:`selector` is automatically added between the
         receiver and the method arguments.
         """
-
         if len(args) != len(self.method_argtypes):
             raise TypeError(
                 f"Method {self.name} takes {len(args)} arguments, but got "
@@ -730,7 +729,6 @@ def type_for_objcclass(objcclass):
     This method is mainly intended for internal use by Rubicon, but is exposed
     in the public API for completeness.
     """
-
     if isinstance(objcclass, ObjCClass):
         objcclass = objcclass.ptr
 
@@ -769,7 +767,6 @@ def register_type_for_objcclass(pytype, objcclass):
         not change, and mappings for subclasses of ``objcclass`` are not
         updated.
     """
-
     if isinstance(objcclass, ObjCClass):
         objcclass = objcclass.ptr
 
@@ -788,7 +785,6 @@ def unregister_type_for_objcclass(objcclass):
         not change, and mappings for subclasses of ``objcclass`` are not
         removed.
     """
-
     if isinstance(objcclass, ObjCClass):
         objcclass = objcclass.ptr
 
@@ -801,7 +797,6 @@ def get_type_for_objcclass_map():
 
     Keys are Objective-C class addresses as :class:`int`\\s.
     """
-
     return dict(_type_for_objcclass_map)
 
 
@@ -849,7 +844,6 @@ class ObjCInstance:
     @property
     def objc_class(self):
         """The Objective-C object's class, as an :class:`ObjCClass`."""
-
         # This property is used inside __getattr__, so any attribute accesses must be
         # done through super(...).__getattribute__ to prevent infinite recursion.
         try:
@@ -904,7 +898,6 @@ class ObjCInstance:
         This ensures that the :class:`ObjCInstance` can always be used from Python
         without segfaults while preventing Rubicon from leaking memory.
         """
-
         # Make sure that object_ptr is wrapped in an objc_id.
         if not isinstance(object_ptr, objc_id):
             object_ptr = cast(object_ptr, objc_id)
@@ -1117,7 +1110,6 @@ class ObjCInstance:
         Otherwise, the name should refer to an Objective-C property, whose
         setter method is called with ``value``.
         """
-
         if name in self.__dict__:
             # For attributes already in __dict__, use the default __setattr__.
             super(ObjCInstance, type(self)).__setattr__(self, name, value)
@@ -1187,7 +1179,6 @@ class ObjCClass(ObjCInstance, type):
     def superclass(self):
         """The superclass of this class, or ``None`` if this is a root class (such as
         :class:`NSObject`)."""
-
         super_ptr = libobjc.class_getSuperclass(self)
         if super_ptr.value is None:
             return None
@@ -1197,7 +1188,6 @@ class ObjCClass(ObjCInstance, type):
     @property
     def protocols(self):
         """The protocols adopted by this class."""
-
         out_count = c_uint()
         protocols_ptr = libobjc.class_copyProtocolList(self, byref(out_count))
         return tuple(ObjCProtocol(protocols_ptr[i]) for i in range(out_count.value))
@@ -1367,7 +1357,6 @@ class ObjCClass(ObjCInstance, type):
         unique name is found). By default, classes will *not* be renamed, unless
         :attr:`ObjCClass.auto_rename` is set at the class level.
         """
-
         if (bases is None) ^ (attrs is None):
             raise TypeError("ObjCClass arguments 2 and 3 must be given together")
 
@@ -1576,7 +1565,6 @@ class ObjCClass(ObjCInstance, type):
             ``NSObject.declare_property('description')``, so that it can always be
             accessed using ``obj.description``.
         """
-
         self.forced_properties.add(name)
 
     def declare_class_property(self, name):
@@ -1585,7 +1573,6 @@ class ObjCClass(ObjCInstance, type):
         This is equivalent to
         ``self.objc_class.declare_property(name)``.
         """
-
         self.objc_class.forced_properties.add(name)
 
     def __repr__(self):
@@ -1606,7 +1593,6 @@ class ObjCClass(ObjCInstance, type):
         of :func:`isinstance`: ``isinstance(obj, NSString)`` is equivalent to
         ``obj.isKindOfClass(NSString)``.
         """
-
         if isinstance(instance, ObjCInstance):
             return bool(instance.isKindOfClass(self))
         else:
@@ -1622,7 +1608,6 @@ class ObjCClass(ObjCInstance, type):
         of :func:`issubclass`: ``issubclass(cls, NSValue)`` is equivalent to
         ``obj.isSubclassOfClass(NSValue)``.
         """
-
         if isinstance(subclass, ObjCClass):
             return bool(subclass.isSubclassOfClass(self))
         else:
@@ -1696,7 +1681,6 @@ class ObjCMetaClass(ObjCClass):
         pointer that might also refer to other kinds of objects.) Creating an
         :class:`ObjCMetaClass` from a ``Nil`` pointer returns ``None``.
         """
-
         if isinstance(name_or_ptr, (bytes, str)):
             name = ensure_bytes(name_or_ptr)
             ptr = libobjc.objc_getMetaClass(name)
@@ -1752,7 +1736,6 @@ def py_from_ns(nsobj):
 
     Other objects are returned unmodified as an :class:`ObjCInstance`.
     """
-
     if isinstance(nsobj, (objc_id, Class)):
         nsobj = ObjCInstance(nsobj)
     if not isinstance(nsobj, ObjCInstance):
@@ -1796,8 +1779,8 @@ def py_from_ns(nsobj):
 
 
 def ns_from_py(pyobj):
-    """Convert a Python object into an equivalent Foundation object. The returned object
-    is autoreleased.
+    """Convert a Python object into an equivalent Foundation object. is autoreleased.
+    The returned object.
 
     This function is also available under the name :func:`at`, because its
     functionality is very similar to that of the Objective-C ``@`` operator and
@@ -1820,7 +1803,6 @@ def ns_from_py(pyobj):
 
     Other types cause a :class:`TypeError`.
     """
-
     if isinstance(pyobj, enum.Enum):
         pyobj = pyobj.value
 
@@ -1875,13 +1857,11 @@ class ObjCProtocol(ObjCInstance):
     @property
     def name(self):
         """The name of this protocol, as a :class:`str`."""
-
         return libobjc.protocol_getName(self).decode("utf-8")
 
     @property
     def protocols(self):
         """The protocols that this protocol extends."""
-
         out_count = c_uint()
         protocols_ptr = libobjc.protocol_copyProtocolList(self, byref(out_count))
         return tuple(ObjCProtocol(protocols_ptr[i]) for i in range(out_count.value))
@@ -1917,7 +1897,6 @@ class ObjCProtocol(ObjCInstance):
         protocols will *not* be renamed, unless
         :attr:`ObjCProtocol.auto_rename` is set at the class level.
         """
-
         if (bases is None) ^ (ns is None):
             raise TypeError("ObjCProtocol arguments 2 and 3 must be given together")
 
@@ -1994,7 +1973,6 @@ class ObjCProtocol(ObjCInstance):
         of :func:`isinstance`: ``isinstance(obj, NSCopying)`` is equivalent to
         ``obj.conformsToProtocol(NSCopying)``.
         """
-
         if isinstance(instance, ObjCInstance):
             return bool(instance.conformsToProtocol(self))
         else:
@@ -2012,7 +1990,6 @@ class ObjCProtocol(ObjCInstance):
         NSCopying)`` is equivalent to ``protocol_conformsToProtocol(proto,
         NSCopying))``.
         """
-
         if isinstance(subclass, ObjCClass):
             return bool(subclass.conformsToProtocol(self))
         elif isinstance(subclass, ObjCProtocol):
@@ -2088,7 +2065,6 @@ def objc_const(dll, name):
     library/framework, such as
     `NSCocoaErrorDomain <https://developer.apple.com/documentation/foundation/nscocoaerrordomain?language=objc>`__.
     """
-
     return ObjCInstance(objc_id.in_dll(dll, name))
 
 
@@ -2199,7 +2175,6 @@ class ObjCBlock:
         return type and parameter types to :class:`ObjCBlock` using the
         ``restype`` and ``argtypes`` parameters.
         """
-
         if isinstance(pointer, ObjCInstance):
             pointer = pointer.ptr
         self.pointer = pointer

--- a/src/rubicon/objc/collections.py
+++ b/src/rubicon/objc/collections.py
@@ -71,7 +71,6 @@ class ObjCStrInstance(ObjCInstance):
         returned depending on whether the result is one of the wanted values. If other
         is not a string, NotImplemented is returned.
         """
-
         if isinstance(other, str):
             ns_other = ns_from_py(other)
         elif isinstance(other, NSString):

--- a/src/rubicon/objc/ctypes_patch.py
+++ b/src/rubicon/objc/ctypes_patch.py
@@ -140,7 +140,6 @@ if sys.version_info < (3, 13):
 
     def unwrap_mappingproxy(proxy):
         """Return the mapping contained in a mapping proxy object."""
-
         if not isinstance(proxy, types.MappingProxyType):
             raise TypeError(
                 "Expected a mapping proxy object, not "
@@ -150,14 +149,13 @@ if sys.version_info < (3, 13):
         return mappingproxyobject.from_address(id(proxy)).mapping
 
     def get_stgdict_of_type(tp):
-        """Return the given ctypes type's StgDict object. If the object's dict is not a
-        StgDict, an error is raised.
+        """Return the given ctypes type's StgDict object. StgDict, an error is raised.
+        If the object's dict is not a.
 
         This function is roughly equivalent to the PyType_stgdict function in the ctypes
         source code. We cannot use that function directly, because it is not part of
         CPython's public C API, and thus not accessible on some systems (see #113).
         """
-
         if not isinstance(tp, type):
             raise TypeError(
                 "Expected a type object, not "

--- a/src/rubicon/objc/runtime.py
+++ b/src/rubicon/objc/runtime.py
@@ -85,7 +85,6 @@ def load_library(name):
     locations, as a fallback for systems where ``find_library`` does not work
     (such as iOS).
     """
-
     path = util.find_library(name)
     if path is not None:
         return CDLL(path)
@@ -153,7 +152,6 @@ class SEL(c_void_p):
     @property
     def name(self):
         """The selector's name as :class:`bytes`."""
-
         if self.value is None:
             raise ValueError("Cannot get name of null selector")
 
@@ -166,7 +164,6 @@ class SEL(c_void_p):
         (The normal arguments supported by :class:`~ctypes.c_void_p` are
         still accepted.)
         """
-
         if isinstance(init, (bytes, str)):
             self = libobjc.sel_registerName(ensure_bytes(init))
             self._inited = True
@@ -500,7 +497,6 @@ except AttributeError:
         This is the emulated version of the object_isClass runtime function, for systems
         older than OS X 10.10 or iOS 8, where the real function doesn't exist yet.
         """
-
         return libobjc.class_isMetaClass(libobjc.object_getClass(obj))
 
 else:
@@ -649,7 +645,6 @@ def ensure_bytes(x):
     If the argument is already :class:`bytes`, it is returned unchanged;
     if it is :class:`str`, it is encoded as UTF-8.
     """
-
     if isinstance(x, bytes):
         return x
     # "All char * in the runtime API should be considered to have UTF-8 encoding."
@@ -666,7 +661,6 @@ def get_class(name):
     If no class with the given name is loaded, ``None`` is returned, and
     the Objective-C runtime will log a warning message.
     """
-
     return libobjc.objc_getClass(ensure_bytes(name))
 
 
@@ -677,7 +671,6 @@ def get_class(name):
 def should_use_stret(restype):
     """Return whether a method returning the given type must be called using
     ``objc_msgSend_stret`` on the current system."""
-
     if type(restype) is not type(Structure):
         # Not needed when restype is not a structure.
         retval = False
@@ -704,7 +697,6 @@ def should_use_stret(restype):
 def should_use_fpret(restype):
     """Return whether a method returning the given type must be called using
     ``objc_msgSend_fpret`` on the current system."""
-
     if __x86_64__:
         # On x86_64: Use only for long double.
         return restype == c_longdouble
@@ -731,7 +723,6 @@ def _msg_send_for_types(restype, argtypes):
         and ``argtypes`` arguments. The ``restype`` and ``argtypes`` attributes
         of the returned function *must not* be modified.
     """
-
     try:
         # Looking up a C function is relatively slow, so use an existing cached
         # function if possible.
@@ -814,7 +805,6 @@ def send_message(receiver, selector, *args, restype, argtypes=None, varargs=None
         Defaults to ``[]``. These arguments are converted according to the
         default :mod:`ctypes` conversion rules.
     """
-
     try:
         receiver = receiver._as_parameter_
     except AttributeError:
@@ -919,7 +909,6 @@ def send_super(
         Defaults to ``[]``. These arguments are converted according to the
         default :mod:`ctypes` conversion rules.
     """
-
     # Unwrap ObjCClass to Class if necessary
     try:
         cls = cls._as_parameter_
@@ -1035,7 +1024,6 @@ def add_method(cls, selector, method, encoding, replace=False):
         this function pointer object to ensure that it isn't garbage-collected.
         Rubicon now does this automatically.)
     """
-
     signature = [ctype_for_type(tp) for tp in encoding]
     assert signature[1] == objc_id  # ensure id self typecode
     assert signature[2] == SEL  # ensure SEL cmd typecode
@@ -1062,7 +1050,6 @@ def add_method(cls, selector, method, encoding, replace=False):
 
 def add_ivar(cls, name, vartype):
     """Add a new instance variable of type ``vartype`` to ``cls``."""
-
     return libobjc.class_addIvar(
         cls,
         ensure_bytes(name),
@@ -1086,7 +1073,6 @@ def get_ivar(obj, varname, weak=False):
     memory. This is because object ``ivars`` may be weak, and thus cannot always
     be accessed directly by their address.
     """
-
     try:
         obj = obj._as_parameter_
     except AttributeError:
@@ -1107,18 +1093,16 @@ def get_ivar(obj, varname, weak=False):
 
 
 def set_ivar(obj, varname, value, weak=False):
-    """Set obj's ``ivar`` ``varname`` to value. If ``weak`` is ``True``, only a weak
-    reference to the value is stored.
+    """Set obj's ``ivar`` ``varname`` to value. reference to the value is stored. If
+    ``weak`` is ``True``, only a weak.
 
     value must be a :mod:`ctypes` data object whose type matches that of
     the ``ivar``.
     """
-
     try:
         obj = obj._as_parameter_
     except AttributeError:
         pass
-
     ivar = libobjc.class_getInstanceVariable(
         libobjc.object_getClass(obj), ensure_bytes(varname)
     )

--- a/src/rubicon/objc/types.py
+++ b/src/rubicon/objc/types.py
@@ -134,26 +134,22 @@ def ctype_for_type(tp):
     :mod:`ctypes` equivalents. Unregistered types (including types that are
     already ctypes) are returned unchanged.
     """
-
     return _ctype_for_type_map.get(tp, tp)
 
 
 def register_ctype_for_type(tp, ctype):
     """Register a conversion from a Python type to a C type."""
-
     _ctype_for_type_map[tp] = ctype
 
 
 def unregister_ctype_for_type(tp):
     """Unregister a conversion from a Python type to a C type."""
-
     del _ctype_for_type_map[tp]
 
 
 def get_ctype_for_type_map():
     """Get a copy of all currently registered type-to-C type conversions as a
     mapping."""
-
     return dict(_ctype_for_type_map)
 
 
@@ -167,7 +163,6 @@ def _end_of_encoding(encoding, start):
     The encoding is not validated very extensively. There are no guarantees what happens
     for invalid encodings; an error may be raised, or a bogus end index may be returned.
     """
-
     if start < 0 or start >= len(encoding):
         raise ValueError(f"Start index {start} not in range({len(encoding)})")
 
@@ -367,7 +362,6 @@ def ctype_for_encoding(encoding):
 
     :raises ValueError: if the conversion fails at any point
     """
-
     # Remove qualifiers, as documented in Table 6-2 here:
     # https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html
     encoding = encoding.lstrip(b"NORVnor")
@@ -393,7 +387,6 @@ def encoding_for_ctype(ctype):
 
     :raises ValueError: if the conversion fails at any point
     """
-
     try:
         return _encoding_for_ctype_map[ctype]
     except KeyError:
@@ -411,7 +404,6 @@ def register_preferred_encoding(encoding, ctype):
     overwritten with the new conversion. To register an encoding without
     overwriting existing conversions, use :func:`register_encoding`.
     """
-
     _ctype_for_encoding_map[encoding] = ctype
     _encoding_for_ctype_map[ctype] = encoding
 
@@ -439,7 +431,6 @@ def register_encoding(encoding, ctype):
     *not* overwritten with the new conversion. To register an encoding and
     overwrite existing conversions, use :func:`register_preferred_encoding`.
     """
-
     _ctype_for_encoding_map.setdefault(encoding, ctype)
     _encoding_for_ctype_map.setdefault(ctype, encoding)
 
@@ -470,7 +461,6 @@ def unregister_encoding(encoding):
 
     If the encoding was not registered previously, nothing happens.
     """
-
     _ctype_for_encoding_map.pop(encoding, None)
 
 
@@ -483,7 +473,6 @@ def unregister_encoding_all(encoding):
 
     If the encoding was not registered previously, nothing happens.
     """
-
     _ctype_for_encoding_map.pop(encoding, None)
     for ct, enc in list(_encoding_for_ctype_map.items()):
         if enc == encoding:
@@ -501,7 +490,6 @@ def unregister_ctype(ctype):
 
     If the C type was not registered previously, nothing happens.
     """
-
     _encoding_for_ctype_map.pop(ctype, default=None)
 
 
@@ -514,7 +502,6 @@ def unregister_ctype_all(ctype):
 
     If the C type was not registered previously, nothing happens.
     """
-
     _encoding_for_ctype_map.pop(ctype, default=None)
     for enc, ct in list(_ctype_for_encoding_map.items()):
         if ct == ctype:
@@ -524,14 +511,12 @@ def unregister_ctype_all(ctype):
 def get_ctype_for_encoding_map():
     """Get a copy of all currently registered encoding-to-C type conversions as a
     map."""
-
     return dict(_ctype_for_encoding_map)
 
 
 def get_encoding_for_ctype_map():
     """Get a copy of all currently registered C type-to-encoding conversions as a
     map."""
-
     return dict(_encoding_for_ctype_map)
 
 
@@ -545,7 +530,6 @@ def split_method_encoding(encoding):
     numbers indicated each argument/return value's offset on the stack. These numbers
     are meaningless on modern architectures.
     """
-
     encodings = []
     start = 0
     while start < len(encoding):
@@ -567,7 +551,6 @@ def ctypes_for_method_encoding(encoding):
     :func:`split_method_encoding`, and then converting each individual type
     encoding using :func:`ctype_for_encoding`.
     """
-
     return [ctype_for_encoding(enc) for enc in split_method_encoding(encoding)]
 
 
@@ -628,7 +611,6 @@ def compound_value_for_sequence(seq, tp):
     a structure or array type, the corresponding value from ``seq`` is
     recursively converted as well.
     """
-
     if issubclass(tp, Structure):
         return _struct_for_sequence(seq, tp)
     elif issubclass(tp, Array):

--- a/tests/test_NSString.py
+++ b/tests/test_NSString.py
@@ -71,7 +71,6 @@ class NSStringTests(unittest.TestCase):
 
     def test_str_nsstring_conversion(self):
         """Python str and NSString can be converted to each other manually."""
-
         for pystr in type(self).TEST_STRINGS:
             with self.subTest(pystr=pystr):
                 nsstr = ns_from_py(pystr)
@@ -81,7 +80,6 @@ class NSStringTests(unittest.TestCase):
 
     def test_nsstring_eq_nsstring(self):
         """Two NSStrings can be checked for equality."""
-
         first = ns_from_py("first")
         second = ns_from_py("second")
 
@@ -91,7 +89,6 @@ class NSStringTests(unittest.TestCase):
 
     def test_str_eq_nsstring(self):
         """A Python str and a NSString can be checked for equality."""
-
         py_first = "first"
         py_second = "second"
         ns_first = ns_from_py(py_first)
@@ -106,13 +103,11 @@ class NSStringTests(unittest.TestCase):
 
     def test_nsstring_as_fspath(self):
         """An NSString can be interpreted as a 'path-like' object."""
-
         # os.path.dirname requires a 'path-like' object.
         self.assertEqual(os.path.dirname(ns_from_py("/path/base/leaf")), "/path/base")
 
     def test_nsstring_compare(self):
         """A NSString can be compared to other strings."""
-
         for py_left in type(self).TEST_STRINGS:
             for py_right in type(self).TEST_STRINGS:
                 with self.subTest(py_left=py_left, py_right=py_right):
@@ -126,7 +121,6 @@ class NSStringTests(unittest.TestCase):
 
     def test_nsstring_in(self):
         """The in operator works on NSString."""
-
         py_haystack = type(self).HAYSTACK
         ns_haystack = ns_from_py(py_haystack)
         for py_needle in type(self).NEEDLES:
@@ -139,7 +133,6 @@ class NSStringTests(unittest.TestCase):
 
     def test_nsstring_len(self):
         """``len()`` works on NSString."""
-
         for pystr in type(self).TEST_STRINGS:
             with self.subTest(pystr=pystr):
                 nsstr = ns_from_py(pystr)
@@ -147,7 +140,6 @@ class NSStringTests(unittest.TestCase):
 
     def test_nsstring_getitem_index(self):
         """The individual elements of a NSString can be accessed."""
-
         for pystr in type(self).TEST_STRINGS:
             with self.subTest(pystr=pystr):
                 nsstr = ns_from_py(pystr)
@@ -156,7 +148,6 @@ class NSStringTests(unittest.TestCase):
 
     def test_nsstring_getitem_slice(self):
         """A NSString can be sliced."""
-
         for pystr in type(self).TEST_STRINGS:
             for step in (None, 1, 2, -1, -2):
                 with self.subTest(pystr=pystr, step=step):
@@ -168,7 +159,6 @@ class NSStringTests(unittest.TestCase):
 
     def test_nsstring_iter(self):
         """A NSString can be iterated over."""
-
         for pystr in type(self).TEST_STRINGS:
             with self.subTest(pystr=pystr):
                 nsstr = ns_from_py(pystr)
@@ -177,7 +167,6 @@ class NSStringTests(unittest.TestCase):
 
     def test_nsstring_find_rfind(self):
         """The find and rfind methods work on NSString."""
-
         py_haystack = type(self).HAYSTACK
         ns_haystack = ns_from_py(py_haystack)
         for py_needle in type(self).NEEDLES:
@@ -195,7 +184,6 @@ class NSStringTests(unittest.TestCase):
 
     def test_nsstring_index_rindex(self):
         """The index and rindex methods work on NSString."""
-
         py_haystack = type(self).HAYSTACK
         ns_haystack = ns_from_py(py_haystack)
         for py_needle in type(self).NEEDLES:
@@ -225,7 +213,6 @@ class NSStringTests(unittest.TestCase):
 
     def test_nsstring_add_radd(self):
         """The + operator works on NSString."""
-
         for py_left in type(self).TEST_STRINGS:
             for py_right in type(self).TEST_STRINGS:
                 with self.subTest(py_left=py_left, py_right=py_right):
@@ -239,7 +226,6 @@ class NSStringTests(unittest.TestCase):
 
     def test_nsstring_mul_rmul(self):
         """The * operator works on NSString."""
-
         for py_str in type(self).TEST_STRINGS:
             for n in (-5, 0, 1, 2, 5):
                 with self.subTest(py_str=py_str, n=n):

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -184,7 +184,6 @@ class BlockTests(unittest.TestCase):
     def test_block_round_trip_no_arguments(self):
         """A block that takes no arguments can be created with both ways of specifying
         types."""
-
         BlockRoundTrip = ObjCClass("BlockRoundTrip")
         instance = BlockRoundTrip.alloc().init()
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -123,13 +123,11 @@ class RubiconTest(unittest.TestCase):
 
     def test_class_by_name(self):
         """An Objective-C class can be looked up by name."""
-
         Example = ObjCClass("Example")
         self.assertEqual(Example.name, "Example")
 
     def test_objcclass_caching(self):
         """ObjCClass instances are cached."""
-
         Example1 = ObjCClass("Example")
         Example2 = ObjCClass("Example")
 
@@ -137,20 +135,17 @@ class RubiconTest(unittest.TestCase):
 
     def test_class_by_pointer(self):
         """An Objective-C class can be created from a pointer."""
-
         example_ptr = libobjc.objc_getClass(b"Example")
         Example = ObjCClass(example_ptr)
         self.assertEqual(Example, ObjCClass("Example"))
 
     def test_nonexistant_class(self):
         """A NameError is raised if a class doesn't exist."""
-
         with self.assertRaises(NameError):
             ObjCClass("DoesNotExist")
 
     def test_metaclass_by_name(self):
         """An Objective-C metaclass can be looked up by name."""
-
         Example = ObjCClass("Example")
         ExampleMeta = ObjCMetaClass("Example")
 
@@ -159,7 +154,6 @@ class RubiconTest(unittest.TestCase):
 
     def test_objcmetaclass_caching(self):
         """ObjCMetaClass instances are cached."""
-
         ExampleMeta1 = ObjCMetaClass("Example")
         ExampleMeta2 = ObjCMetaClass("Example")
 
@@ -167,20 +161,17 @@ class RubiconTest(unittest.TestCase):
 
     def test_metaclass_by_pointer(self):
         """An Objective-C metaclass can be created from a pointer."""
-
         examplemeta_ptr = libobjc.objc_getMetaClass(b"Example")
         ExampleMeta = ObjCMetaClass(examplemeta_ptr)
         self.assertEqual(ExampleMeta, ObjCMetaClass("Example"))
 
     def test_nonexistant_metaclass(self):
         """A NameError is raised if a metaclass doesn't exist."""
-
         with self.assertRaises(NameError):
             ObjCMetaClass("DoesNotExist")
 
     def test_metametaclass(self):
         """The class of a metaclass can be looked up."""
-
         ExampleMeta = ObjCMetaClass("Example")
         ExampleMetaMeta = ExampleMeta.objc_class
 
@@ -189,13 +180,11 @@ class RubiconTest(unittest.TestCase):
 
     def test_protocol_by_name(self):
         """An Objective-C protocol can be looked up by name."""
-
         ExampleProtocol = ObjCProtocol("ExampleProtocol")
         self.assertEqual(ExampleProtocol.name, "ExampleProtocol")
 
     def test_protocol_caching(self):
         """ObjCProtocol instances are cached."""
-
         ExampleProtocol1 = ObjCProtocol("ExampleProtocol")
         ExampleProtocol2 = ObjCProtocol("ExampleProtocol")
 
@@ -203,20 +192,17 @@ class RubiconTest(unittest.TestCase):
 
     def test_protocol_by_pointer(self):
         """An Objective-C protocol can be created from a pointer."""
-
         example_protocol_ptr = libobjc.objc_getProtocol(b"ExampleProtocol")
         ExampleProtocol = ObjCProtocol(example_protocol_ptr)
         self.assertEqual(ExampleProtocol, ObjCProtocol("ExampleProtocol"))
 
     def test_nonexistant_protocol(self):
         """A NameError is raised if a protocol doesn't exist."""
-
         with self.assertRaises(NameError):
             ObjCProtocol("DoesNotExist")
 
     def test_objcinstance_can_produce_objcclass(self):
         """Creating an ObjCInstance for a class pointer gives an ObjCClass."""
-
         example_ptr = libobjc.objc_getClass(b"Example")
         Example = ObjCInstance(example_ptr)
         self.assertEqual(Example, ObjCClass("Example"))
@@ -224,7 +210,6 @@ class RubiconTest(unittest.TestCase):
 
     def test_objcinstance_can_produce_objcmetaclass(self):
         """Creating an ObjCInstance for a metaclass pointer gives an ObjCMetaClass."""
-
         examplemeta_ptr = libobjc.objc_getMetaClass(b"Example")
         ExampleMeta = ObjCInstance(examplemeta_ptr)
         self.assertEqual(ExampleMeta, ObjCMetaClass("Example"))
@@ -232,7 +217,6 @@ class RubiconTest(unittest.TestCase):
 
     def test_objcclass_can_produce_objcmetaclass(self):
         """Creating an ObjCClass for a metaclass pointer gives an ObjCMetaclass."""
-
         examplemeta_ptr = libobjc.objc_getMetaClass(b"Example")
         ExampleMeta = ObjCClass(examplemeta_ptr)
         self.assertEqual(ExampleMeta, ObjCMetaClass("Example"))
@@ -240,7 +224,6 @@ class RubiconTest(unittest.TestCase):
 
     def test_objcinstance_can_produce_objcprotocol(self):
         """Creating an ObjCInstance for a protocol pointer gives an ObjCProtocol."""
-
         example_protocol_ptr = libobjc.objc_getProtocol(b"ExampleProtocol")
         ExampleProtocol = ObjCInstance(example_protocol_ptr)
         self.assertEqual(ExampleProtocol, ObjCProtocol("ExampleProtocol"))
@@ -248,14 +231,12 @@ class RubiconTest(unittest.TestCase):
 
     def test_objcclass_requires_class(self):
         """ObjCClass only accepts class pointers."""
-
         random_obj = NSObject.alloc().init()
         with self.assertRaises(ValueError):
             ObjCClass(random_obj.ptr)
 
     def test_objcmetaclass_requires_metaclass(self):
         """ObjCMetaClass only accepts metaclass pointers."""
-
         random_obj = NSObject.alloc().init()
         with self.assertRaises(ValueError):
             ObjCMetaClass(random_obj.ptr)
@@ -265,34 +246,28 @@ class RubiconTest(unittest.TestCase):
 
     def test_objcprotocol_requires_protocol(self):
         """ObjCProtocol only accepts protocol pointers."""
-
         random_obj = NSObject.alloc().init()
         with self.assertRaises(ValueError):
             ObjCProtocol(random_obj.ptr)
 
     def test_objcclass_superclass(self):
         """An ObjCClass's superclass can be looked up."""
-
         Example = ObjCClass("Example")
         BaseExample = ObjCClass("BaseExample")
-
         self.assertEqual(Example.superclass, BaseExample)
         self.assertEqual(BaseExample.superclass, NSObject)
         self.assertIsNone(NSObject.superclass)
 
     def test_objcmetaclass_superclass(self):
         """An ObjCMetaClass's superclass can be looked up."""
-
         Example = ObjCClass("Example")
         BaseExample = ObjCClass("BaseExample")
-
         self.assertEqual(Example.objc_class.superclass, BaseExample.objc_class)
         self.assertEqual(BaseExample.objc_class.superclass, NSObject.objc_class)
         self.assertEqual(NSObject.objc_class.superclass, NSObject)
 
     def test_objcclass_protocols(self):
         """An ObjCClass's protocols can be looked up."""
-
         BaseExample = ObjCClass("BaseExample")
         ExampleProtocol = ObjCProtocol("ExampleProtocol")
         DerivedProtocol = ObjCProtocol("DerivedProtocol")
@@ -301,7 +276,6 @@ class RubiconTest(unittest.TestCase):
 
     def test_objcprotocol_protocols(self):
         """An ObjCProtocol's protocols can be looked up."""
-
         DerivedProtocol = ObjCProtocol("DerivedProtocol")
         BaseProtocolOne = ObjCProtocol("BaseProtocolOne")
         BaseProtocolTwo = ObjCProtocol("BaseProtocolTwo")
@@ -341,10 +315,8 @@ class RubiconTest(unittest.TestCase):
 
     def test_objcprotocol_instancecheck(self):
         """``isinstance()`` works with an ObjCProtocol as the second argument."""
-
         NSCoding = ObjCProtocol("NSCoding")
         NSSecureCoding = ObjCProtocol("NSSecureCoding")
-
         self.assertIsInstance(at(""), NSSecureCoding)
         self.assertIsInstance(at(""), NSCoding)
 
@@ -356,7 +328,6 @@ class RubiconTest(unittest.TestCase):
         NSCopying = ObjCProtocol("NSCopying")
         NSCoding = ObjCProtocol("NSCoding")
         NSSecureCoding = ObjCProtocol("NSSecureCoding")
-
         self.assertTrue(issubclass(NSObject, NSObjectProtocol))
         self.assertTrue(issubclass(NSString, NSObjectProtocol))
         self.assertTrue(issubclass(NSSecureCoding, NSSecureCoding))
@@ -375,11 +346,9 @@ class RubiconTest(unittest.TestCase):
 
     def test_field(self):
         """A field on an instance can be accessed and mutated."""
-
         Example = ObjCClass("Example")
 
         obj = Example.alloc().init()
-
         self.assertEqual(obj.baseIntField, 22)
         self.assertEqual(obj.intField, 33)
 
@@ -394,7 +363,6 @@ class RubiconTest(unittest.TestCase):
         Example = ObjCClass("Example")
 
         obj = Example.alloc().init()
-
         self.assertEqual(obj.accessBaseIntField(), 22)
         self.assertEqual(obj.accessIntField(), 33)
 
@@ -407,10 +375,8 @@ class RubiconTest(unittest.TestCase):
     def test_method_incorrect_argument_count(self):
         """Attempting to call a method with an incorrect number of arguments throws an
         exception."""
-
         Example = ObjCClass("Example")
         obj = Example.alloc().init()
-
         with self.assertRaises(TypeError):
             obj.accessIntField("extra argument 1")
 
@@ -423,10 +389,8 @@ class RubiconTest(unittest.TestCase):
     def test_method_incorrect_argument_type(self):
         """Attempting to call a method with the wrong type of argument throws an
         exception."""
-
         Example = ObjCClass("Example")
         obj = Example.alloc().init()
-
         with self.assertRaisesRegex(
             ArgumentError,
             r"mutateIntFieldWithValue: argument 3: "
@@ -446,10 +410,8 @@ class RubiconTest(unittest.TestCase):
     def test_method_incorrect_argument_count_send(self):
         """Attempting to call a method with send_message with an incorrect number of
         arguments throws an exception."""
-
         Example = ObjCClass("Example")
         obj = Example.alloc().init()
-
         with self.assertRaises(TypeError):
             send_message(
                 obj, "accessIntField", "extra argument 1", restype=c_int, argtypes=[]
@@ -489,7 +451,6 @@ class RubiconTest(unittest.TestCase):
         Example = ObjCClass("Example")
 
         obj = Example.alloc().init()
-
         self.assertEqual(
             send_message(obj, "accessBaseIntField", restype=c_int, argtypes=[]), 22
         )
@@ -516,7 +477,6 @@ class RubiconTest(unittest.TestCase):
         Example = ObjCClass("Example")
 
         obj = Example.alloc().init()
-
         self.assertEqual(
             send_message(obj, SEL("accessIntField"), restype=c_int, argtypes=[]), 33
         )
@@ -526,7 +486,6 @@ class RubiconTest(unittest.TestCase):
         SpecificExample = ObjCClass("SpecificExample")
 
         obj = SpecificExample.alloc().init()
-
         send_super(
             SpecificExample,
             obj,
@@ -544,7 +503,6 @@ class RubiconTest(unittest.TestCase):
         SpecificExample = ObjCClass("SpecificExample")
 
         obj = SpecificExample.alloc().init()
-
         send_super(
             SpecificExample,
             obj,
@@ -563,7 +521,6 @@ class RubiconTest(unittest.TestCase):
         SpecificExample = ObjCClass("SpecificExample")
 
         obj = SpecificExample.alloc().init()
-
         with self.assertRaises(TypeError):
             send_super(
                 SpecificExample, obj, "method:withArg:", 2, restype=None, argtypes=[]
@@ -611,10 +568,8 @@ class RubiconTest(unittest.TestCase):
     def test_static_field(self):
         """A static field on a class can be accessed and mutated."""
         Example = ObjCClass("Example")
-
         Example.mutateStaticBaseIntFieldWithValue_(1)
         Example.mutateStaticIntFieldWithValue_(11)
-
         self.assertEqual(Example.staticBaseIntField, 1)
         self.assertEqual(Example.staticIntField, 11)
 
@@ -627,10 +582,8 @@ class RubiconTest(unittest.TestCase):
     def test_static_method(self):
         """A static method on a class can be invoked."""
         Example = ObjCClass("Example")
-
         Example.mutateStaticBaseIntFieldWithValue_(2288)
         Example.mutateStaticIntFieldWithValue_(2299)
-
         self.assertEqual(Example.accessStaticBaseIntField(), 2288)
         self.assertEqual(Example.accessStaticIntField(), 2299)
 
@@ -639,10 +592,8 @@ class RubiconTest(unittest.TestCase):
         Example = ObjCClass("Example")
 
         obj1 = Example.alloc().init()
-
         # setSpecialValue: looks like it might be a mutator
         # for a specialValue property, but this property doesn't exist.
-
         # We can invoke the method directly...
         obj1.setSpecialValue_(42)
 
@@ -692,7 +643,6 @@ class RubiconTest(unittest.TestCase):
         Example = ObjCClass("Example")
 
         obj1 = Example.alloc().init()
-
         # Non-existent fields raise an error.
         with self.assertRaises(AttributeError):
             _ = obj1.field_doesnt_exist
@@ -706,7 +656,6 @@ class RubiconTest(unittest.TestCase):
         Example = ObjCClass("Example")
 
         obj1 = Example.alloc().init()
-
         # Non-existent methods raise an error.
         with self.assertRaises(AttributeError):
             obj1.method_doesnt_exist()
@@ -722,7 +671,6 @@ class RubiconTest(unittest.TestCase):
         # Non-existent fields raise an error.
         with self.assertRaises(AttributeError):
             _ = Example.static_field_doesnt_exist
-
         # Cache warming doesn't affect anything.
         with self.assertRaises(AttributeError):
             _ = Example.static_field_doesnt_exist
@@ -734,7 +682,6 @@ class RubiconTest(unittest.TestCase):
         # Non-existent methods raise an error.
         with self.assertRaises(AttributeError):
             Example.static_method_doesnt_exist()
-
         # Cache warming doesn't affect anything.
         with self.assertRaises(AttributeError):
             Example.static_method_doesnt_exist()
@@ -765,7 +712,6 @@ class RubiconTest(unittest.TestCase):
         Example = ObjCClass("Example")
 
         obj = Example.alloc().init()
-
         with self.assertRaises(AttributeError):
             _ = obj.staticIntField
 
@@ -778,7 +724,6 @@ class RubiconTest(unittest.TestCase):
 
         with self.assertRaises(AttributeError):
             _ = Example.intField
-
         with self.assertRaises(AttributeError):
             Example.accessIntField()
 
@@ -793,7 +738,6 @@ class RubiconTest(unittest.TestCase):
         Example = ObjCClass("Example")
 
         obj = Example.alloc().init()
-
         self.assertEqual(obj.accessBaseIntField(), 22)
         self.assertEqual(obj.accessIntField(), 33)
 
@@ -894,7 +838,6 @@ class RubiconTest(unittest.TestCase):
     def test_auto_struct_creation(self):
         """Structs from method signatures are created automatically."""
         Example = ObjCClass("Example")
-
         types.unregister_encoding_all(b"{simple=ii}")
         types.unregister_encoding_all(b"{simple}")
         types.unregister_encoding_all(b"{complex=[4s]^?{simple=ii}^{complex}}")
@@ -934,7 +877,6 @@ class RubiconTest(unittest.TestCase):
         """Methods returning structs of different sizes by value can be handled."""
         Example = ObjCClass("Example")
         example = Example.alloc().init()
-
         types.register_encoding(b"{int_sized=[4c]}", struct_int_sized)
         self.assertEqual(example.intSizedStruct().x, b"abc")
 
@@ -949,7 +891,6 @@ class RubiconTest(unittest.TestCase):
         using send_message."""
         Example = ObjCClass("Example")
         example = Example.alloc().init()
-
         self.assertEqual(
             send_message(
                 example, "intSizedStruct", restype=struct_int_sized, argtypes=[]
@@ -1050,9 +991,7 @@ class RubiconTest(unittest.TestCase):
 
     def test_objcmethod_str_repr(self):
         """Test ObjCMethod, ObjCPartialMethod, and ObjCBoundMethod str and repr."""
-
         obj = NSObject.new()
-
         # ObjCMethod
         self.assertEqual(repr(obj.init.method), "<ObjCMethod: init @16@0:8>")
         self.assertEqual(str(obj.init.method), "<ObjCMethod: init @16@0:8>")
@@ -1078,7 +1017,6 @@ class RubiconTest(unittest.TestCase):
     def test_objcinstance_str_repr(self):
         """An ObjCInstance's str and repr contain the object's description and
         debugDescription, respectively."""
-
         DescriptionTester = ObjCClass("DescriptionTester")
         py_description_string = "normal description string"
         py_debug_description_string = "debug description string"
@@ -1100,7 +1038,6 @@ class RubiconTest(unittest.TestCase):
     def test_objcinstance_str_repr_with_nil_descriptions(self):
         """An ObjCInstance's str and repr work even if description and debugDescription
         are nil."""
-
         DescriptionTester = ObjCClass("DescriptionTester")
         tester = DescriptionTester.alloc().initWithDescriptionString(
             None, debugDescriptionString=None
@@ -1110,25 +1047,21 @@ class RubiconTest(unittest.TestCase):
 
     def test_objcclass_repr(self):
         """Test ObjCClass repr and str return correct value."""
-
         self.assertEqual(repr(NSObject), "<ObjCClass: NSObject>")
         self.assertEqual(str(NSObject), "ObjCClass('NSObject')")
 
     def test_objcprotocol_repr(self):
         """Test ObjCProtocol repr return correct value."""
-
         self.assertEqual(repr(NSObjectProtocol), "<ObjCProtocol: NSObject>")
 
     def test_nspoint_repr(self):
         """Test NSPoint repr and str returns correct value."""
-
         my_point = NSPoint(10, 20)
         self.assertEqual(repr(my_point), "<NSPoint(10.0, 20.0)>")
         self.assertEqual(str(my_point), "(10.0, 20.0)")
 
     def test_cgpoint_repr(self):
         """Test CGPoint repr and str returns correct value."""
-
         my_point = CGPoint(10, 20)
         if __LP64__:
             self.assertEqual(repr(my_point), "<NSPoint(10.0, 20.0)>")
@@ -1138,7 +1071,6 @@ class RubiconTest(unittest.TestCase):
 
     def test_nsrect_repr(self):
         """Test NSRect repr and str returns correct value."""
-
         my_rect = NSRect(NSPoint(10, 20), NSSize(5, 15))
         self.assertEqual(
             repr(my_rect),
@@ -1148,7 +1080,6 @@ class RubiconTest(unittest.TestCase):
 
     def test_cgrect_repr(self):
         """Test CGRect repr and str returns correct value."""
-
         my_rect = CGRect(CGPoint(10, 20), CGSize(5, 15))
         if __LP64__:
             self.assertEqual(
@@ -1165,14 +1096,12 @@ class RubiconTest(unittest.TestCase):
 
     def test_nssize_repr(self):
         """Test NSSize repr and str returns correct value."""
-
         my_size = NSSize(5, 15)
         self.assertEqual(repr(my_size), "<NSSize(5.0, 15.0)>")
         self.assertEqual(str(my_size), "5.0 x 15.0")
 
     def test_cgsize_repr(self):
         """Test NSSize repr and str returns correct value."""
-
         my_size = CGSize(5, 15)
         if __LP64__:
             self.assertEqual(repr(my_size), "<NSSize(5.0, 15.0)>")
@@ -1182,21 +1111,18 @@ class RubiconTest(unittest.TestCase):
 
     def test_nsrange_repr(self):
         """Test NSRange repr and str returns correct value."""
-
         my_range = NSRange(5, 6)
         self.assertEqual(repr(my_range), "<NSRange(5, 6)>")
         self.assertEqual(str(my_range), "location=5, length=6")
 
     def test_cfrange_repr(self):
         """Test NSRange repr and str returns correct value."""
-
         my_range = CFRange(5, 6)
         self.assertEqual(repr(my_range), "<CFRange(5, 6)>")
         self.assertEqual(str(my_range), "location=5, length=6")
 
     def test_nsedgeinsets_repr(self):
         """Test NSRange repr and str returns correct value."""
-
         my_edge_insets = NSEdgeInsets(4, 5, 6, 7)
         self.assertEqual(repr(my_edge_insets), "<NSEdgeInsets(4.0, 5.0, 6.0, 7.0)>")
         self.assertEqual(
@@ -1205,7 +1131,6 @@ class RubiconTest(unittest.TestCase):
 
     def test_uiedgeinsets_repr(self):
         """Test NSRange repr and str returns correct value."""
-
         my_edge_insets = UIEdgeInsets(4, 5, 6, 7)
         self.assertEqual(repr(my_edge_insets), "<UIEdgeInsets(4.0, 5.0, 6.0, 7.0)>")
         self.assertEqual(
@@ -1228,7 +1153,6 @@ class RubiconTest(unittest.TestCase):
 
     def test_class_auto_rename_global(self):
         """Test the global automatic renaming option of ObjCClass."""
-
         try:
             ObjCClass.auto_rename = True
 
@@ -1290,7 +1214,6 @@ class RubiconTest(unittest.TestCase):
 
     def test_protocol_auto_rename_global(self):
         """Test the global automatic renaming option of ObjCProtocol."""
-
         try:
             ObjCProtocol.auto_rename = True
 
@@ -1337,7 +1260,6 @@ class RubiconTest(unittest.TestCase):
 
     def test_interface(self):
         """An ObjC protocol implementation can be defined in Python."""
-
         Callback = ObjCProtocol("Callback")
         results = {}
 
@@ -1409,7 +1331,6 @@ class RubiconTest(unittest.TestCase):
 
     def test_no_duplicate_protocols(self):
         """An Objective-C class cannot adopt a protocol more than once."""
-
         with self.assertRaises(ValueError):
 
             class DuplicateProtocol(
@@ -1446,7 +1367,6 @@ class RubiconTest(unittest.TestCase):
     def test_class_properties(self):
         """A Python class can have ObjC properties with synthesized getters and setters
         of ObjCInstance type."""
-
         NSURL = ObjCClass("NSURL")
 
         class URLBox(NSObject):
@@ -1684,7 +1604,6 @@ class RubiconTest(unittest.TestCase):
 
     def test_protocol_def_extends(self):
         """An ObjCProtocol that extends other protocols can be defined."""
-
         ExampleProtocol = ObjCProtocol("ExampleProtocol")
 
         class ProtocolExtendsProtocols(NSObjectProtocol, ExampleProtocol):
@@ -1696,10 +1615,8 @@ class RubiconTest(unittest.TestCase):
 
     def test_function_NSEdgeInsetsMake(self):
         """Python can invoke NSEdgeInsetsMake to create NSEdgeInsets."""
-
         insets = NSEdgeInsets(0.0, 1.1, 2.2, 3.3)
         other_insets = NSEdgeInsetsMake(0.0, 1.1, 2.2, 3.3)
-
         # structs are NOT equal
         self.assertNotEqual(insets, other_insets)
 
@@ -1711,14 +1628,12 @@ class RubiconTest(unittest.TestCase):
 
     def test_objc_const(self):
         """objc_const works."""
-
         string_const = objc_const(rubiconharness, "SomeGlobalStringConstant")
         self.assertEqual(str(string_const), "Some global string constant")
 
     def test_interface_return_struct(self):
         """An ObjC protocol implementation that returns values by struct can be defined
         in Python."""
-
         results = {}
         Thing = ObjCClass("Thing")
 
@@ -1801,7 +1716,6 @@ class RubiconTest(unittest.TestCase):
 
     def test_objcinstance_python_attribute(self):
         """Python attributes can be added to an ObjCInstance."""
-
         Thing = ObjCClass("Thing")
         thing = Thing.alloc().init()
 
@@ -1823,12 +1737,10 @@ class RubiconTest(unittest.TestCase):
     def test_objcinstance_python_attribute_keep_alive(self):
         """Python attributes on an ObjCInstance are kept even if the object temporarily
         has no Python references."""
-
         Example = ObjCClass("Example")
         example = Example.alloc().init()
         Thing = ObjCClass("Thing")
         thing = Thing.alloc().init()
-
         # Use objects that don't have an obvious Objective-C equivalent,
         # to ensure that the actual Python objects are being stored,
         # and not converted Objective-C versions.
@@ -1871,7 +1783,6 @@ class RubiconTest(unittest.TestCase):
     def test_objcinstance_python_attribute_freed(self):
         """Python attributes on an ObjCInstance are freed after the instance is
         released."""
-
         with autoreleasepool():
             obj = NSObject.alloc().init()
 
@@ -1960,7 +1871,6 @@ class RubiconTest(unittest.TestCase):
         def create_object():
             obj = NSMutableArray.alloc().init()
             copy = obj.copy()
-
             # Check that the copy is a new object.
             self.assertIsNot(obj, copy)
             self.assertNotEqual(obj.ptr.value, copy.ptr.value)
@@ -1979,7 +1889,6 @@ class RubiconTest(unittest.TestCase):
         def create_object():
             obj = NSMutableArray.alloc().init()
             copy = obj.mutableCopy()
-
             # Check that the copy is a new object.
             self.assertIsNot(obj, copy)
             self.assertNotEqual(obj.ptr.value, copy.ptr.value)
@@ -2090,7 +1999,6 @@ class RubiconTest(unittest.TestCase):
         # This mirrors what happens with NSWindow, where `init()` changes the
         # class name to NSKVONotifying_NSWindow.
         post_init = pre_init.initWithClassChange()
-
         # Memory address hasn't changed
         assert pre_init.ptr.value == post_init.ptr.value
         # The class name hasn't changed either
@@ -2106,7 +2014,6 @@ class RubiconTest(unittest.TestCase):
         Example = ObjCClass("Example")
         obj = Example.alloc().init()
         ptr = obj.ptr
-
         # The underlying problem is a race condition, so we need to try a
         # bunch of times to make it happen.
         for _ in range(0, 1000):

--- a/tests/test_ctypes_patch.py
+++ b/tests/test_ctypes_patch.py
@@ -75,7 +75,6 @@ class CtypesPatchTest(unittest.TestCase):
 
     def test_no_patch_primitives(self):
         """Primitive types cannot be patched."""
-
         for tp in (ctypes.c_int, ctypes.c_double, ctypes.c_char_p, ctypes.c_void_p):
             with self.subTest(tp), self.assertRaises(ValueError):
                 ctypes_patch.make_callback_returnable(tp)


### PR DESCRIPTION
Bumps `pre-commit` hook for `docformatter` from v1.7.7 to v1.7.8-rc1 and ran the update against the repo.