### PR TITLE
Ensure CocoaLifecycle doesn't terminate the app.

### DIFF
--- a/changes/745.bugfix.md
+++ b/changes/745.bugfix.md
@@ -1,0 +1,1 @@
+Stopping a `CocoaLifecycle` event loop no longer terminates the `NSApplication` instance when it stops.

--- a/changes/746.feature.md
+++ b/changes/746.feature.md
@@ -1,0 +1,1 @@
+The `CFLifecycle` will now use the default run loop if a loop instance isn't provided when it is constructed.

--- a/src/rubicon/objc/eventloop.py
+++ b/src/rubicon/objc/eventloop.py
@@ -818,8 +818,11 @@ else:  # pragma: no-cover-if-lt-py314
 class CFLifecycle:
     """A lifecycle manager for raw CoreFoundation apps."""
 
-    def __init__(self, cfrunloop):
-        self._cfrunloop = cfrunloop
+    def __init__(self, cfrunloop=None):
+        if cfrunloop:
+            self._cfrunloop = cfrunloop
+        else:
+            self._cfrunloop = libcf.CFRunLoopGetMain()
 
     def start(self):
         libcf.CFRunLoopRun()
@@ -838,10 +841,10 @@ class CocoaLifecycle:
         self._application.run()
 
     def stop(self):
-        self._application.terminate(None)
+        self._application.stop(None)
 
 
-class iOSLifecycle:
+class iOSLifecycle:  # pragma: no cover
     """A life cycle manager for iOS (`UIApplication`) apps."""
 
     def start(self):

--- a/src/rubicon/objc/eventloop.py
+++ b/src/rubicon/objc/eventloop.py
@@ -530,10 +530,7 @@ class CFEventLoop(unix_events.SelectorEventLoop):
                 "To recursively run the event loop, call run()."
             )
 
-        try:
-            self.run()
-        finally:
-            self.stop()
+        self.run()
 
     def run_forever_cooperatively(self, lifecycle=None):
         """A non-blocking version of

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -6,7 +6,11 @@ import time
 
 import pytest
 
-from rubicon.objc.eventloop import RubiconEventLoop
+from rubicon.objc import NSMakePoint, ObjCClass
+from rubicon.objc.eventloop import CFLifecycle, CocoaLifecycle, RubiconEventLoop, libcf
+
+NSApplication = ObjCClass("NSApplication")
+NSEvent = ObjCClass("NSEvent")
 
 
 # Some coroutines with known behavior for testing purposes.
@@ -170,3 +174,41 @@ def test_subprocess(loop):
     # Everything in the sample set, less everything from the result,
     # should be an empty set.
     assert ({"README.md"} - task.result()) == set()
+
+
+def test_cf_lifecycle(loop):
+    """The simple CFLifecycle works."""
+    loop.create_task(stop_loop(loop, 0.6))
+    loop.run_forever(lifecycle=CFLifecycle())
+
+
+def test_cf_lifecycle_explicit(loop):
+    """The simple CFLifecycle works with an explicit event loop."""
+    loop.create_task(stop_loop(loop, 0.6))
+    loop.run_forever(lifecycle=CFLifecycle(libcf.CFRunLoopGetMain()))
+
+
+def test_cocoa_lifecycle(loop):
+    """The full Cocoa Lifecycle works."""
+
+    # Shutting down the Cooca event loop needs a followup event to ensure that
+    # post-stop processing occurs.
+    async def shutdown(delay):
+        await asyncio.sleep(delay)
+        loop.stop()
+        event = NSEvent.otherEventWithType(
+            15,
+            location=NSMakePoint(0, 0),
+            modifierFlags=0,
+            timestamp=0,
+            windowNumber=0,
+            context=None,
+            subtype=0,
+            data1=0,
+            data2=0,
+        )
+        NSApplication.sharedApplication.postEvent(event, atStart=True)
+
+    loop.create_task(shutdown(0.6))
+
+    loop.run_forever(lifecycle=CocoaLifecycle(NSApplication.sharedApplication))


### PR DESCRIPTION
Fixes #745 

Modifies the `stop()` method on CocoaLifecycle to just stop the event loop, rather than fully terminating the app.

Includes tests for the CFLifecycle and CocoaLifecycle, plus a cleanup of the constructor for CFLifecycle so that an explicit event loop isn't required.

I've tested this with the test case provided in the discussion on beeware/toga#4320, and with the `Window` example in the Toga repo (which has complex on-exit logic); both seem to work with this change.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
