### PR TITLE
Allow for keyword arguments when adding and removing readers.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,7 @@ jobs:
       run: python -m pip install --group tox-uv
 
     - name: Test
+      timeout-minutes: 5
       run: |
         RUNNER_OS=$(cut -d- -f1 <<< ${{ matrix.platform }})
         RUNNER_VERSION=$(cut -d- -f2 <<< ${{ matrix.platform }})

--- a/changes/747.bugfix.md
+++ b/changes/747.bugfix.md
@@ -1,0 +1,1 @@
+The event loop has been updated to accommodate an internal `context` keyword argument used when adding and removing socket readers in Python 3.15.0a8.

--- a/src/rubicon/objc/eventloop.py
+++ b/src/rubicon/objc/eventloop.py
@@ -386,7 +386,7 @@ class CFEventLoop(unix_events.SelectorEventLoop):
         libcf.CFRelease(self._cfrunloop)
         super().__del__()
 
-    def _add_reader(self, fd, callback, *args):
+    def _add_reader(self, fd, callback, *args, **kwargs):
         try:
             handle = self._sockets[fd]
         except KeyError:
@@ -418,7 +418,7 @@ class CFEventLoop(unix_events.SelectorEventLoop):
         """
         self._remove_reader(fd)
 
-    def _add_writer(self, fd, callback, *args):
+    def _add_writer(self, fd, callback, *args, **kwargs):
         try:
             handle = self._sockets[fd]
         except KeyError:


### PR DESCRIPTION
Fixes #747.

Python 3.15.0a8 added a `context` keyword argument to `_add_reader()` and `_remove_reader()` calls. This adds a `**kwargs` handling so that those methods can be invoked.

Also adds a timeout to the test suite; the default 2 hours timeout caused todays' dependabot run to stall due to lack of available macOS runners.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
