### PR TITLE
Cosmetic ordering change in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,10 +104,10 @@ jobs:
         include:
         # Also run the oldest supported Python on macos-14,
         # and the newest non-dev Python on macos-26.
-        - python-version: "3.10"
-          platform: macos-14
-        - python-version: "3.14"
-          platform: macos-26
+        - platform: macos-14
+          python-version: "3.10"
+        - platform: macos-26
+          python-version: "3.14"
 
     steps:
     - name: Checkout

--- a/changes/756.misc.md
+++ b/changes/756.misc.md
@@ -1,0 +1,1 @@
+A cosmetic ordering issue in CI was resolved.

--- a/docs/en/about/releases.md
+++ b/docs/en/about/releases.md
@@ -16,7 +16,7 @@
 
 ### Documentation
 
-* A new contribution guide has been added documentation. ([#688](https://github.com/beeware/rubicon-objc/issues/688))
+* A new contribution guide has been added to the documentation. ([#688](https://github.com/beeware/rubicon-objc/issues/688))
 
 ### Misc
 


### PR DESCRIPTION
A completely cosmetic change in the ordering of CI matrix flags - but one that means the macOS-14, Python 3.10 test is reported as "macOS-14, python3.10" rather than the other way around.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x]  I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
