### PR TITLE
Correct link checking rules for markdown-checker

### DIFF
--- a/changes/759.misc.md
+++ b/changes/759.misc.md
@@ -1,0 +1,1 @@
+Link checking rules were updated.

--- a/tox.ini
+++ b/tox.ini
@@ -87,7 +87,7 @@ commands =
     !lint-!all-!live-!en : build_md_translations {posargs} en --source-code=stubs
     lint : pyspelling
     # cppreference has added a Cloudflare robot check.
-    # Github, Wikipedia, Wiktionary and superuser.com have aggressive rate limiters
+    # Github has an aggressive rate limiters
     lint : markdown-checker --dir {[docs]docs_dir} --func check_broken_urls --skip-urls-containing=https://en.cppreference.com/,https://github.com/beeware,https://github.com/python/cpython
     live : live_serve_en {posargs} src stubs --source-code=stubs --port=8040
     all : build_md_translations {posargs} en --source-code=stubs

--- a/tox.ini
+++ b/tox.ini
@@ -87,7 +87,8 @@ commands =
     !lint-!all-!live-!en : build_md_translations {posargs} en --source-code=stubs
     lint : pyspelling
     # cppreference has added a Cloudflare robot check.
-    lint : markdown-checker --dir {[docs]docs_dir} --func check_broken_urls --skip-domains=https://en.cppreference.com/
+    # Github, Wikipedia, Wiktionary and superuser.com have aggressive rate limiters
+    lint : markdown-checker --dir {[docs]docs_dir} --func check_broken_urls --skip-urls-containing=https://en.cppreference.com/,https://github.com/beeware,https://github.com/python/cpython
     live : live_serve_en {posargs} src stubs --source-code=stubs --port=8040
     all : build_md_translations {posargs} en --source-code=stubs
     en : build_md_translations {posargs} en --source-code=stubs


### PR DESCRIPTION
A recent update to markdown checker added validation of Github rules, which triggers rate limiters. This PR tweaks the exclusion list to avoid those rate checkers.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
