### PR TITLE
Bump ruff-pre-commit from v0.15.12 to v0.15.13

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: docformatter
         args: [--in-place, --black]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.12
+    rev: v0.15.13
     hooks:
       - id: ruff-format
       - id: ruff-check

--- a/changes/760.misc.md
+++ b/changes/760.misc.md
@@ -1,0 +1,1 @@
+The `pre-commit` hook for `ruff-pre-commit` was updated to its latest version.


### PR DESCRIPTION
Bumps `pre-commit` hook for `ruff-pre-commit` from v0.15.12 to v0.15.13 and ran the update against the repo.