### PR TITLE
Correct build issues caused by vcs_versioning==2.0

### DIFF
--- a/changes/779.misc.md
+++ b/changes/779.misc.md
@@ -1,0 +1,1 @@
+Some issues with setuptools_scm configuration were resolved.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools==82.0.1",
-    "setuptools_scm==10.0.5",
+    "setuptools_scm==10.1.2",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -54,7 +54,7 @@ pre-commit = [
 ]
 
 setuptools-scm = [
-    "setuptools_scm == 10.0.5",
+    "setuptools_scm==10.1.2",
 ]
 
 towncrier = [

--- a/src/rubicon/objc/__init__.py
+++ b/src/rubicon/objc/__init__.py
@@ -5,7 +5,10 @@ try:
 
     # Excluded from coverage because a pure test environment (such as the one
     # used by tox in CI) won't have setuptools_scm
-    __version__ = get_version("../../..", relative_to=__file__)  # pragma: no cover
+    # The tag_regex argument is needed as a workaround for setuptools_scm#1434
+    __version__ = get_version(
+        "../../..", relative_to=__file__, tag_regex=None
+    )  # pragma: no cover
 except (ModuleNotFoundError, LookupError):  # pragma: no-cover-if-missing-setuptools_scm
     # If setuptools_scm isn't in the environment, the call to import will fail.
     # If it *is* in the environment, but the code isn't a git checkout (e.g.,

--- a/src/rubicon/objc/__init__.py
+++ b/src/rubicon/objc/__init__.py
@@ -1,23 +1,4 @@
-try:
-    # Read version from SCM metadata
-    # This will only exist in a development environment
-    from setuptools_scm import get_version
-
-    # Excluded from coverage because a pure test environment (such as the one
-    # used by tox in CI) won't have setuptools_scm
-    # The tag_regex argument is needed as a workaround for setuptools_scm#1434
-    __version__ = get_version(
-        "../../..", relative_to=__file__, tag_regex=None
-    )  # pragma: no cover
-except (ModuleNotFoundError, LookupError):  # pragma: no-cover-if-missing-setuptools_scm
-    # If setuptools_scm isn't in the environment, the call to import will fail.
-    # If it *is* in the environment, but the code isn't a git checkout (e.g.,
-    # it's been pip installed non-editable) the call to get_version() will fail.
-    # If either of these occurs, read version from the installer metadata.
-
-    from importlib.metadata import version
-
-    __version__ = version("rubicon-objc")
+from importlib.metadata import version
 
 # `api`, `runtime` and `types` are only included for clarity. They are not
 # strictly necessary, because the from-imports below also import the types and
@@ -146,3 +127,5 @@ __all__ = [
     "runtime",
     "types",
 ]
+
+__version__ = version("rubicon-objc")

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ commands =
 [docs]
 docs_dir = {tox_root}{/}docs{/}en
 
-[testenv:docs{,-lint,-all,-live,-en}]
+[testenv:docs{,-lint,-links,-all,-live,-en}]
 # Docs are always built on Python 3.12. See also the RTD config and contribution docs.
 base_python = py312
 setenv =
@@ -84,11 +84,11 @@ package = wheel
 wheel_build_env = .pkg
 dependency_groups = docs
 commands =
-    !lint-!all-!live-!en : build_md_translations {posargs} en --source-code=stubs
+    !lint-!links-!all-!live-!en : build_md_translations {posargs} en --source-code=stubs
     lint : pyspelling
     # cppreference has added a Cloudflare robot check.
     # Github has an aggressive rate limiters
-    lint : markdown-checker --dir {[docs]docs_dir} --func check_broken_urls --skip-urls-containing=https://en.cppreference.com/,https://github.com/beeware,https://github.com/python/cpython
+    links : markdown-checker --dir {[docs]docs_dir} --func check_broken_urls --skip-urls-containing=https://en.cppreference.com/,https://github.com/beeware,https://github.com/python/cpython
     live : live_serve_en {posargs} src stubs --source-code=stubs --port=8040
     all : build_md_translations {posargs} en --source-code=stubs
     en : build_md_translations {posargs} en --source-code=stubs

--- a/tox.ini
+++ b/tox.ini
@@ -80,6 +80,7 @@ docs_dir = {tox_root}{/}docs{/}en
 base_python = py312
 setenv =
     DISABLE_MKDOCS_2_WARNING = true
+    NO_MKDOCS_2_WARNING = 1
 package = wheel
 wheel_build_env = .pkg
 dependency_groups = docs


### PR DESCRIPTION
Over the last 24 hours, vsc_versioning 2.0 has been released; this has caused problems with scm_versioning.

There's an underlying bug (pypa/setuptools-scm#1434). Based on the recommendation from the maintainers on that ticket, this simplifies version handling to always use importlib metadata. 

The direct call to get_version() may have been needed historically because importlib.metadata hadn't been fully formalized, but it isn't any more. The only consequence I can see is that an editable install won't necessarily show the *current* VCS version.

Also includes some tweaks to the docs configuration that are shared with other projects (disabling a MkDocs 2 warning, and moving the link checker out of the linting task)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
