### PR TITLE
Correct handling of NSEvent on iOS.

### DIFF
--- a/changes/786.bugfix.md
+++ b/changes/786.bugfix.md
@@ -1,0 +1,1 @@
+An issue with the 0.5.5 release on iOS related to the use of NSEvent was resolved.

--- a/src/rubicon/objc/eventloop.py
+++ b/src/rubicon/objc/eventloop.py
@@ -114,7 +114,8 @@ kCFSocketWriteCallBack = 8
 kCFSocketAutomaticallyReenableReadCallBack = 1
 kCFSocketAutomaticallyReenableWriteCallBack = 8
 
-NSEvent = ObjCClass("NSEvent")
+if sys.platform != "ios":
+    NSEvent = ObjCClass("NSEvent")
 NSRunLoop = ObjCClass("NSRunLoop")
 
 ###########################################################################


### PR DESCRIPTION
Skip the import of NSEvent on iOS.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
