### PR TITLE
Add zizmor pre-commit configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -16,6 +18,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pre-commit"
     directory: "/"
@@ -24,3 +28,5 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "20:00"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -7,4 +7,6 @@ on:
 jobs:
   check-pr-template:
     name: Check PR template
-    uses: beeware/.github/.github/workflows/pr-checklist.yml@main
+    permissions:
+      contents: read
+    uses: beeware/.github/.github/workflows/pr-checklist.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,9 @@ jobs:
     uses: beeware/.github/.github/workflows/pre-commit-run.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
     with:
       pre-commit-source: "--group pre-commit"
-      python-version: "3.13"  # docformatter is not compatible with 3.14
 
   towncrier:
     name: Check towncrier
-    # Mirror the permissions the reusable workflow declares; granting less
-    # than the called workflow requests is rejected at workflow startup.
     permissions:
       contents: read
       pull-requests: write
@@ -69,8 +66,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 1
-          # Nothing in this job pushes, so the token doesn't need to be
-          # persisted in .git/config.
           persist-credentials: false
 
       - name: Set up Python
@@ -197,8 +192,6 @@ jobs:
 
     - name: Project Coverage Report
       id: project-coverage
-      # (the second clause references the unit-tests job; there is no
-      # "platform-coverage" job, so the old condition was vacuously true)
       if: always() || contains(fromJSON('["success", "failure"]'), needs.unit-tests.result)
       run: tox -qe coverage-ci-project-html
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash
@@ -30,14 +33,14 @@ env:
 jobs:
   pre-commit:
     name: Pre-commit checks
-    uses: beeware/.github/.github/workflows/pre-commit-run.yml@main
+    uses: beeware/.github/.github/workflows/pre-commit-run.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
     with:
       pre-commit-source: "--group pre-commit"
       python-version: "3.13"  # docformatter is not compatible with 3.14
 
   towncrier:
     name: Check towncrier
-    uses: beeware/.github/.github/workflows/towncrier-run.yml@main
+    uses: beeware/.github/.github/workflows/towncrier-run.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
     with:
       tox-source: "--group tox-uv"
 
@@ -47,7 +50,7 @@ jobs:
       id-token: write
       contents: read
       attestations: write
-    uses: beeware/.github/.github/workflows/python-package-create.yml@main
+    uses: beeware/.github/.github/workflows/python-package-create.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
     with:
       attest: ${{ inputs.attest-package }}
 
@@ -58,12 +61,15 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 1
+          # Nothing in this job pushes, so the token doesn't need to be
+          # persisted in .git/config.
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.X"
           cache: pip
@@ -111,18 +117,19 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v7.0.0
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6.3.0
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
 
     - name: Get packages
-      uses: actions/download-artifact@v8.0.1
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       with:
         name: ${{ needs.package.outputs.artifact-name }}
         path: dist
@@ -131,6 +138,7 @@ jobs:
       run: python -m pip install --group tox-uv
 
     - name: Test
+      id: test
       timeout-minutes: 5
       run: |
         RUNNER_OS=$(cut -d- -f1 <<< ${{ matrix.platform }})
@@ -139,8 +147,8 @@ jobs:
           tox -e py-cov --installpkg dist/rubicon_objc-*.whl
 
     - name: Store Coverage Data
-      if: always() && contains('success,failure', steps.test.outcome)
-      uses: actions/upload-artifact@v7.0.1
+      if: always() && contains(fromJSON('["success", "failure"]'), steps.test.outcome)
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
         name: coverage-data-${{ matrix.platform }}-${{ matrix.python-version }}
         path: ".coverage.*"
@@ -149,7 +157,7 @@ jobs:
 
     - name: Report Platform Coverage
       id: coverage
-      if: always() && contains('success,failure', steps.test.outcome)
+      if: always() && contains(fromJSON('["success", "failure"]'), steps.test.outcome)
       # coverage reporting must use the same Python version used to produce coverage
       run: tox -qe coverage$(tr -dc "0-9" <<< "${{ matrix.python-version }}")
 
@@ -158,15 +166,16 @@ jobs:
     name: Project coverage
     runs-on: ubuntu-24.04
     needs: unit-tests
-    if: always() && contains('success,failure', needs.unit-tests.result)
+    if: always() && contains(fromJSON('["success", "failure"]'), needs.unit-tests.result)
     steps:
     - name: Checkout
-      uses: actions/checkout@v7.0.0
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Setup Python
-      uses: actions/setup-python@v6.3.0
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
       with:
         # Use minimum version of python for coverage to avoid phantom branches
         # https://github.com/nedbat/coveragepy/issues/1572#issuecomment-1522546425
@@ -176,19 +185,21 @@ jobs:
       run: python -m pip install --group tox-uv
 
     - name: Retrieve Coverage Data
-      uses: actions/download-artifact@v8.0.1
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       with:
         pattern: coverage-data-*
         merge-multiple: true
 
     - name: Project Coverage Report
       id: project-coverage
-      if: always() || contains('success,failure', needs.platform-coverage.result)
+      # (the second clause references the unit-tests job; there is no
+      # "platform-coverage" job, so the old condition was vacuously true)
+      if: always() || contains(fromJSON('["success", "failure"]'), needs.unit-tests.result)
       run: tox -qe coverage-ci-project-html
 
     - name: Upload Project Coverage HTML Report
       if: always() && steps.project-coverage.outcome == 'failure'
-      uses: actions/upload-artifact@v7.0.1
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
         name: html-coverage-report-project
         path: htmlcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,11 @@ jobs:
 
   towncrier:
     name: Check towncrier
+    # Mirror the permissions the reusable workflow declares; granting less
+    # than the called workflow requests is rejected at workflow startup.
+    permissions:
+      contents: read
+      pull-requests: write
     uses: beeware/.github/.github/workflows/towncrier-run.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
     with:
       tox-source: "--group tox-uv"

--- a/.github/workflows/dependabot-changenote.yml
+++ b/.github/workflows/dependabot-changenote.yml
@@ -8,7 +8,13 @@ on:
 jobs:
   changenote:
     name: Dependabot Change Note
-    uses: beeware/.github/.github/workflows/dependabot-changenote.yml@main
-    secrets: inherit
+    # Mirror the permissions the reusable workflow declares; the push itself
+    # is authenticated with BRUTUS_PAT_TOKEN, not the job's GITHUB_TOKEN.
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: beeware/.github/.github/workflows/dependabot-changenote.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
+    secrets:
+      BRUTUS_PAT_TOKEN: ${{ secrets.BRUTUS_PAT_TOKEN }}
     with:
       changenote-format: "md"

--- a/.github/workflows/dependabot-changenote.yml
+++ b/.github/workflows/dependabot-changenote.yml
@@ -8,8 +8,6 @@ on:
 jobs:
   changenote:
     name: Dependabot Change Note
-    # Mirror the permissions the reusable workflow declares; the push itself
-    # is authenticated with BRUTUS_PAT_TOKEN, not the job's GITHUB_TOKEN.
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/new-issue.yml
+++ b/.github/workflows/new-issue.yml
@@ -11,8 +11,11 @@ jobs:
   add-to-project:
     name: Add issue to BeeWare project
     runs-on: ubuntu-latest
+    # The add-to-project action authenticates with BRUTUS_PAT_TOKEN, so the
+    # job's own GITHUB_TOKEN needs no permissions.
+    permissions: {}
     steps:
-      - uses: actions/add-to-project@v2.0.0
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd  # v2.0.0
         with:
           project-url: https://github.com/orgs/beeware/projects/1
           github-token: ${{ secrets.BRUTUS_PAT_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
       # This permission is required for trusted publishing.
       id-token: write
     steps:
-      - uses: dsaltares/fetch-gh-release-asset@1.1.2
+      - uses: dsaltares/fetch-gh-release-asset@aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7  # 1.1.2
         with:
           version: tags/${{ github.event.release.tag_name }}
           # This next line is *not* a bash filename expansion - it's a regex.
@@ -22,4 +22,4 @@ jobs:
           target: dist/
 
       - name: Publish release to production PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,4 +22,4 @@ jobs:
           target: dist/
 
       - name: Publish release to production PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,17 +5,29 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: CI
+    # The called workflow's package job needs id-token/attestations to
+    # create the provenance attestation.
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/ci.yml
     with:
       attest-package: "true"
 
   docs:
     name: Verify Docs Build
-    uses: beeware/.github/.github/workflows/docs-build-verify.yml@main
-    secrets: inherit
+    permissions:
+      contents: read
+    uses: beeware/.github/.github/workflows/docs-build-verify.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
+    secrets:
+      RTD_API_TOKEN: ${{ secrets.RTD_API_TOKEN }}
     with:
       project-name: "rubicon-objc"
       project-version: ${{ github.ref_name }}
@@ -33,12 +45,12 @@ jobs:
           echo "VERSION=${GITHUB_REF_NAME#v}" | tee -a $GITHUB_ENV
 
       - name: Set up Python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.X"
 
       - name: Get packages
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: ${{ needs.ci.outputs.artifact-name }}
           path: dist
@@ -54,12 +66,17 @@ jobs:
           test $(python -c "from rubicon.objc import __version__; print(__version__)") = $VERSION
 
       - name: Create Release
-        uses: ncipollo/release-action@v1.21.0
-        with:
-          name: ${{ env.VERSION }}
-          draft: true
-          artifacts: dist/*
-          artifactErrorsFailBuild: true
+        # gh is provided by the runner, so a third-party release action isn't
+        # needed; gh fails the step if any artifact upload fails.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${VERSION}" \
+            --draft \
+            --verify-tag \
+            dist/*
 
   test-publish:
     name: Publish test package
@@ -71,12 +88,12 @@ jobs:
       id-token: write
     steps:
       - name: Get packages
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: ${{ needs.ci.outputs.artifact-name }}
           path: dist
 
       - name: Publish release to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,6 @@ permissions:
 jobs:
   ci:
     name: CI
-    # The called workflow's package job needs id-token/attestations to
-    # create the provenance attestation, and its towncrier job needs
-    # pull-requests (mirroring the towncrier-run reusable workflow).
     permissions:
       contents: read
       id-token: write
@@ -68,8 +65,6 @@ jobs:
           test $(python -c "from rubicon.objc import __version__; print(__version__)") = $VERSION
 
       - name: Create Release
-        # gh is provided by the runner, so a third-party release action isn't
-        # needed; gh fails the step if any artifact upload fails.
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
@@ -96,6 +91,6 @@ jobs:
           path: dist
 
       - name: Publish release to Test PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,13 @@ jobs:
   ci:
     name: CI
     # The called workflow's package job needs id-token/attestations to
-    # create the provenance attestation.
+    # create the provenance attestation, and its towncrier job needs
+    # pull-requests (mirroring the towncrier-run reusable workflow).
     permissions:
       contents: read
       id-token: write
       attestations: write
+      pull-requests: write
     uses: ./.github/workflows/ci.yml
     with:
       attest-package: "true"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,7 @@ repos:
       additional_dependencies:
         - tomli
       args: ["--skip=CODE_OF_CONDUCT.md"]
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.27.0
+    hooks:
+    - id: zizmor

--- a/changes/794.misc.md
+++ b/changes/794.misc.md
@@ -1,0 +1,1 @@
+The pre-commit configuration now includes zizmor, and the GitHub Actions workflows pass its audit with actions hash-pinned and least-privilege permissions.


### PR DESCRIPTION
Adds [zizmor](https://docs.zizmor.sh) to the pre-commit pipeline, as requested in #793, and fixes every finding it reports on the existing GitHub Actions configuration. Follows the approach of beeware/.github#378.

## Changes

- **`.pre-commit-config.yaml`**: add the `zizmor` hook (v1.27.0).
- **unpinned-uses**: every action and reusable-workflow reference is pinned to a full commit hash (`checkout` v7.0.0, `setup-python` v6.3.0, `download-artifact` v8.0.1, `upload-artifact` v7.0.1, `add-to-project` v2.0.0, `fetch-gh-release-asset` 1.1.2, `gh-action-pypi-publish` release/v1 head, and `beeware/.github` pinned to current `main`, 741cc5a).
- **excessive-permissions**: explicit least-privilege `permissions:` on every workflow/job. `release.yml`'s `ci` job explicitly forwards `id-token: write` + `attestations: write` so package attestation keeps working; `new-issue.yml` gets `permissions: {}` since it authenticates with `BRUTUS_PAT_TOKEN`.
- **secrets-inherit**: `docs-build-verify` and `dependabot-changenote` now receive their declared secrets (`RTD_API_TOKEN`, `BRUTUS_PAT_TOKEN`) explicitly instead of `secrets: inherit`.
- **artipacked**: all checkouts set `persist-credentials: false`; nothing in those jobs pushes.
- **unsound-contains**: `contains('success,failure', ...)` conditions replaced with the sound `contains(fromJSON('["success", "failure"]'), ...)` form. While doing this I found the *Test* step had no `id: test`, so `steps.test.outcome` was always empty and the coverage-store/report conditions were vacuously true — the step now has the id, making the conditions behave as written. Similarly, `needs.platform-coverage` referenced a job that doesn't exist; it now references `unit-tests` (the actual dependency; the `always() ||` semantics are unchanged).
- **superfluous-actions**: release creation now uses the runner's `gh` CLI (`gh release create --draft --verify-tag dist/*`) instead of `ncipollo/release-action` — same draft release with artifacts, and the step still fails if an artifact upload fails. Happy to revert this piece if you'd rather keep the action.
- **dependabot-cooldown**: 7-day cooldown on all three ecosystems, matching beeware/.github#378.

`zizmor .github/` now reports **no findings**, and `pre-commit run --all-files` passes with the new hook.

Fixes #793

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by: Claude Fable 5 (Claude Code)