### PR TITLE
Load AppKit before accessing NSEvent in macOS event loop

### DIFF
--- a/changes/806.bugfix.md
+++ b/changes/806.bugfix.md
@@ -1,0 +1,1 @@
+The macOS event loop now loads AppKit before accessing NSEvent, fixing a NameError when the event loop is imported before any other framework that loads AppKit (e.g. in non-toga headless apps).

--- a/changes/806.bugfix.md
+++ b/changes/806.bugfix.md
@@ -1,1 +1,1 @@
-The macOS event loop now loads AppKit before accessing NSEvent, fixing a NameError when the event loop is imported before any other framework that loads AppKit (e.g. in non-toga headless apps).
+The macOS event loop integration no longer requires an explicit load of the `AppKit` library before being imported.

--- a/src/rubicon/objc/eventloop.py
+++ b/src/rubicon/objc/eventloop.py
@@ -115,6 +115,7 @@ kCFSocketAutomaticallyReenableReadCallBack = 1
 kCFSocketAutomaticallyReenableWriteCallBack = 8
 
 if sys.platform != "ios":
+    load_library("AppKit")
     NSEvent = ObjCClass("NSEvent")
 NSRunLoop = ObjCClass("NSRunLoop")
 


### PR DESCRIPTION
## Problem

When `rubicon.objc.eventloop` is imported before any framework that has already loaded AppKit (e.g. in headless daemons or CLI apps that don't use toga), `ObjCClass("NSEvent")` raises `NameError: ObjC Class b'NSEvent' couldn't be found` because AppKit isn't registered in the Objective-C runtime yet.

This is the macOS equivalent of #786 (which is iOS-specific). It affects apps that import `rubicon.objc.eventloop` directly for a CoreFoundation-based asyncio event loop without first loading AppKit through another dependency.

### Reproducer

```python
# Fresh interpreter, no other rubicon/AppKit imports first
from rubicon.objc.eventloop import EventLoopPolicy
```

On macOS (any version, tested on Python 3.14 + rubicon-objc 0.5.6) this crashes with:

```
NameError: ObjC Class b'NSEvent' couldn't be found.
```

## Fix

Call `load_library("AppKit")` before accessing `NSEvent`, mirroring how `CoreFoundation` is already loaded for the CF types at the top of the module. `load_library` is already imported in this module.

`NSRunLoop` is available from Foundation (which `rubicon.objc` loads transitively), so only `NSEvent` needs AppKit.

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
  - Assisted-by: Oh My Pi (OMP) with Kimi K3
- [ ] This PR will generate a changelog entry