### PR TITLE
Update pypa/gh-action-pypi-publish pin comment to v1.14.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,4 +22,4 @@ jobs:
           target: dist/
 
       - name: Publish release to production PyPI
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.0
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # v1.14.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,6 @@ jobs:
           path: dist
 
       - name: Publish release to Test PyPI
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.0
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # v1.14.1
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/changes/808.misc.md
+++ b/changes/808.misc.md
@@ -1,0 +1,1 @@
+Updated the pinned reference for pypa/gh-action-pypi-publish to correctly reference v1.14.1.


### PR DESCRIPTION
The `pypa/gh-action-pypi-publish` action is pinned to commit `ba38be9e461d3875417946c167d0b5f3d385a247`, which corresponds to tag `v1.14.1`. The trailing comment incorrectly referenced an older version; this corrects it.

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by: Claude Sonnet 5
