### PR TITLE
test: Add tests for ctypes type lookup error paths

### DIFF
--- a/changes/729.misc.1.md
+++ b/changes/729.misc.1.md
@@ -1,0 +1,1 @@
+Test coverage of the error paths in the ctypes `StgDict`/`StgInfo` type lookup helpers has been improved.

--- a/tests/test_ctypes_patch.py
+++ b/tests/test_ctypes_patch.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ctypes
+import sys
 
 import pytest
 
@@ -136,3 +137,51 @@ def test_patched_type_returned_often():
         struct = get_struct()
         assert struct.spam == 123
         assert struct.ham == 123
+
+before_313 = pytest.mark.skipif(
+    sys.version_info >= (3, 13),
+    reason="StgDict was replaced by StgInfo in Python 3.13",
+)
+since_313 = pytest.mark.skipif(
+    sys.version_info < (3, 13),
+    reason="StgInfo was introduced in Python 3.13",
+)
+
+
+@before_313
+def test_unwrap_mappingproxy_not_a_proxy():
+    """Unwrapping something other than a mapping proxy is a TypeError."""
+    with pytest.raises(TypeError, match="Expected a mapping proxy object"):
+        ctypes_patch.unwrap_mappingproxy({"spam": 1})
+
+
+@before_313
+@pytest.mark.parametrize("value", [42, "abc", None, ctypes.c_int(1)])
+def test_get_stgdict_of_type_not_a_type(value):
+    """Looking up the StgDict of a non-type is a TypeError."""
+    with pytest.raises(TypeError, match="Expected a type object"):
+        ctypes_patch.get_stgdict_of_type(value)
+
+
+@before_313
+@pytest.mark.parametrize("tp", [int, str, object])
+def test_get_stgdict_of_type_not_a_ctype(tp):
+    """Looking up the StgDict of a non-ctypes type is a TypeError."""
+    with pytest.raises(TypeError, match="must be a StgDict"):
+        ctypes_patch.get_stgdict_of_type(tp)
+
+
+@since_313
+@pytest.mark.parametrize("tp", [42, "abc", None, int, object])
+def test_get_stginfo_of_type_not_a_ctype(tp):
+    """Looking up the StgInfo of anything but a ctypes type is a TypeError."""
+    with pytest.raises(TypeError, match="Expected a ctypes structure type"):
+        ctypes_patch.get_stginfo_of_type(tp)
+
+
+@since_313
+@pytest.mark.parametrize("tp", [ctypes.Structure, ctypes.Union])
+def test_get_stginfo_of_type_uninitialized(tp):
+    """The abstract ctypes base classes have no initialized StgInfo."""
+    with pytest.raises(TypeError, match="has not been initialized"):
+        ctypes_patch.get_stginfo_of_type(tp)

--- a/tests/test_ctypes_patch.py
+++ b/tests/test_ctypes_patch.py
@@ -138,6 +138,7 @@ def test_patched_type_returned_often():
         assert struct.spam == 123
         assert struct.ham == 123
 
+
 before_313 = pytest.mark.skipif(
     sys.version_info >= (3, 13),
     reason="StgDict was replaced by StgInfo in Python 3.13",


### PR DESCRIPTION
Adds tests for the error paths of the helpers that locate a ctypes type's StgDict/StgInfo.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: Claude Opus 5 (Claude Code)