### PR TITLE
Drop support for Python 3.10.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,11 +106,8 @@ jobs:
           "macos-26",
         ]
         python-version: [ "3.11", "3.12", "3.13", "3.14", "3.15" ]
-
         include:
-        # Also run the oldest supported Python on macos-14, and macos-15
-        - platform: macos-14
-          python-version: "3.11"
+        # Also run the oldest supported Python on macos-15
         - platform: macos-15
           python-version: "3.11"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,22 +98,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Run all Python versions on macOS 15, intel + ARM
+        # Run all Python versions on macOS 26, intel + ARM
         platform: [
           # X86-64 runner
-          "macos-15-intel",
+          "macos-26-intel",
           # M1 runner
-          "macos-15",
+          "macos-26",
         ]
-        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14", "3.15" ]
+        python-version: [ "3.11", "3.12", "3.13", "3.14", "3.15" ]
 
         include:
-        # Also run the oldest supported Python on macos-14,
-        # and the newest non-dev Python on macos-26.
+        # Also run the oldest supported Python on macos-14, and macos-15
         - platform: macos-14
-          python-version: "3.10"
-        - platform: macos-26
-          python-version: "3.14"
+          python-version: "3.11"
+        - platform: macos-15
+          python-version: "3.11"
 
     steps:
     - name: Checkout

--- a/changes/822.removal.md
+++ b/changes/822.removal.md
@@ -1,0 +1,1 @@
+Support for Python 3.10 has been removed.

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -15,9 +15,9 @@ extra:
   package_name: rubicon-objc
   formal_name: Rubicon ObjC
   macos_only: true
-  min_python_version: "3.10"  # The oldest supported Python version
-  min_python_version_tag: "310"  # The tag version of the minimum python version
-  recent_python_version: "3.13"  # The newest Python version known to work on all platforms
+  min_python_version: "3.11"  # The oldest supported Python version
+  min_python_version_tag: "311"  # The tag version of the minimum python version
+  recent_python_version: "3.14"  # The newest Python version known to work on all platforms
   docs_python_version: "3.13"  # The version of Python required to build the documentation
   contribution_guide_root: how-to/contribute
   social:

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -18,7 +18,7 @@ extra:
   min_python_version: "3.11"  # The oldest supported Python version
   min_python_version_tag: "311"  # The tag version of the minimum python version
   recent_python_version: "3.14"  # The newest Python version known to work on all platforms
-  docs_python_version: "3.13"  # The version of Python required to build the documentation
+  docs_python_version: "3.12"  # The version of Python required to build the documentation
   contribution_guide_root: how-to/contribute
   social:
     - icon: fontawesome/brands/github

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = ["version"]
 name = "rubicon-objc"
 description = "A bridge between an Objective C runtime environment and Python."
 readme = "README.md"
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 license = "BSD-3-Clause"
 license-files = [
     "LICENSE",
@@ -31,7 +31,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Programming Language :: Objective C",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,14 @@
 [tox]
-envlist = towncrier-check,pre-commit,docs{,-lint,-all},py{310,311,312,313,314,315}-cov,coverage-platform,py{310,311,312,313,314,315}
+envlist = towncrier-check,pre-commit,docs{,-lint,-all},py{311,312,313,314,315}-cov,coverage-platform,py{311,312,313,314,315}
 labels =
     test = py-cov,coverage
-    test310 = py310-cov,coverage310
     test311 = py311-cov,coverage311
     test312 = py312-cov,coverage312
     test313 = py313-cov,coverage313
     test314 = py314-cov,coverage314
     test315 = py315-cov,coverage315
-    test-fast = py{310,311,312,313,314,315}-fast
-    test-platform = py{310,311,312,313,314,315}-cov,coverage-platform
+    test-fast = py{311,312,313,314,315}-fast
+    test-platform = py{311,312,313,314,315}-cov,coverage-platform
 skip_missing_interpreters = true
 
 [testenv:pre-commit]
@@ -18,7 +17,7 @@ wheel_build_env = .pkg
 dependency_groups = pre-commit
 commands = pre-commit run --all-files --show-diff-on-failure --color=always
 
-[testenv:py{,310,311,312,313,314,315}{,-fast,-cov}]
+[testenv:py{,311,312,313,314,315}{,-fast,-cov}]
 package = wheel
 wheel_build_env = .pkg
 depends = pre-commit
@@ -35,15 +34,14 @@ commands =
     cov  : python -X warn_default_encoding -m coverage run -m pytest {posargs:-vv --color yes}
     fast : python -m pytest {posargs:-vv --color yes -n auto}
 
-[testenv:coverage{,310,311,312,313,314,315}{,-ci}{,-platform,-platform-macos,-project}{,-keep}{,-html}]
+[testenv:coverage{,311,312,313,314,315}{,-ci}{,-platform,-platform-macos,-project}{,-keep}{,-html}]
 package = wheel
 wheel_build_env = .pkg
-depends = pre-commit,py{,310,311,312,313,314,315}{,-cov}
+depends = pre-commit,py{,311,312,313,314,315}{,-cov}
 # by default, coverage should run on oldest supported Python for testing platform coverage.
 # however, coverage for a particular Python version should match the version used for pytest.
 base_python =
-    coverage: py310,py311,py312,py313,py314,py315
-    coverage310: py310
+    coverage: py311,py312,py313,py314,py315
     coverage311: py311
     coverage312: py312
     coverage313: py313


### PR DESCRIPTION
Drop support for Python 3.10

Bumps CI configuration to use macOS-26 for most testing, and drops use of the (soon to be deprecated) macOS-14 runner.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
