### PR TITLE
fix: encoding_for_ctype() raises ValueError instead of AttributeError for unknown ctypes

### DIFF
--- a/changes/826.bugfix.md
+++ b/changes/826.bugfix.md
@@ -1,0 +1,1 @@
+`encoding_for_ctype()` now raises `ValueError`, as documented, for a ctype with no known encoding; previously it raised an undocumented `AttributeError`.

--- a/src/rubicon/objc/types.py
+++ b/src/rubicon/objc/types.py
@@ -387,7 +387,7 @@ def encoding_for_ctype(ctype):
     except KeyError:
         try:
             return b"^" + encoding_for_ctype(ctype._type_)
-        except KeyError as exc:
+        except AttributeError as exc:
             raise ValueError(f"No type encoding known for ctype {ctype}") from exc
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -416,13 +416,8 @@ def test_encoding_for_ctype_pointer():
 
 
 def test_encoding_for_unknown_ctype():
-    """A ctype that cannot be converted raises an error.
-
-    The documented error is a `ValueError`, but a type without a known encoding is
-    assumed to be a pointer type, so the missing `_type_` attribute surfaces as an
-    `AttributeError` before the `ValueError` can be raised.
-    """
-    with pytest.raises(AttributeError, match="has no attribute '_type_'"):
+    """A ctype that cannot be converted raises a ValueError."""
+    with pytest.raises(ValueError, match="No type encoding known for ctype"):
         encoding_for_ctype(UnregisteredStruct)
 
 


### PR DESCRIPTION
`encoding_for_ctype()` raised an undocumented `AttributeError` instead of the documented `ValueError` for ctypes with no known encoding (e.g. a `Structure`/`Union`), because the fallback path only caught `KeyError` while it should have caught `AttributeError`.

Fixes #826.

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by: Claude Sonnet 5